### PR TITLE
Fix rename command to return correct file path after rename

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/service/java/JavaService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/JavaService.java
@@ -630,15 +630,9 @@ public class JavaService {
         modifiedFile.save();
         // System.out.println(modifiedFile.getFile().getName());
       }
-      // For class renames, return the new file path; for others, return the original
-      String resultPath = filePath.toString();
-      if (identifierType.equals(JavaIdentifierType.CLASS_NAME)
-          && this.shouldRenameFileName(file, currentName)) {
-        resultPath = filePath.resolveSibling(newName + ".java").toString();
-      }
       return DataTransferObject.success(
           RenameResponse.builder()
-              .filePath(resultPath)
+              .filePath(file.getFile().getAbsolutePath())
               .renamedNodes(renamedNodes)
               .newName(newName)
               .build());


### PR DESCRIPTION
- Replace manual path calculation with file.getFile().getAbsolutePath()
- Ensures the response returns the actual current file path after any rename operations
- Fixes issue where old file name was returned instead of new one