### PR TITLE
refactor: remove class-level JavaDoc and fix dependency injection

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/Core.java
+++ b/src/main/java/io/github/syntaxpresso/core/Core.java
@@ -81,7 +81,7 @@ public class Core {
     FieldDeclarationService fieldDeclarationService = new FieldDeclarationService();
     ClassDeclarationService classDeclarationService =
         new ClassDeclarationService(fieldDeclarationService, methodDeclarationService);
-    PackageDeclarationService packageDeclarationService = new PackageDeclarationService();
+    PackageDeclarationService packageDeclarationService = new PackageDeclarationService(pathHelper);
     ImportDeclarationService importDeclarationService = new ImportDeclarationService();
     LocalVariableDeclarationService localVariableDeclarationService =
         new LocalVariableDeclarationService();

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
@@ -14,57 +14,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and manipulating annotation declarations in Java source code using
- * tree-sitter.
- *
- * <p>This service provides comprehensive functionality for working with annotations within Java
- * source files, including extraction of annotation information, finding annotations by name, and
- * analyzing annotation arguments. It leverages tree-sitter queries to accurately parse and analyze
- * annotation declarations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting annotation name, argument pairs, keys and values
- *   <li>Finding annotations by name within a scope
- *   <li>Handling both marker annotations and annotations with arguments
- *   <li>Accessing individual annotation argument pairs
- *   <li>Retrieving specific annotation values by key
- *   <li>Getting structured AnnotationArgument objects with both key and value nodes
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * AnnotationService annotationService = new AnnotationService();
- *
- * // Find an annotation by name
- * Optional&lt;TSNode&gt; tableAnnotation = annotationService.findAnnotationByName(tsFile, scopeNode, "Table");
- * if (tableAnnotation.isPresent()) {
- *   // Get arguments as structured objects
- *   Map&lt;String, AnnotationArgument&gt; args = annotationService.getAnnotationArguments(tsFile, tableAnnotation.get());
- *
- *   AnnotationArgument nameArg = args.get("name");
- *   if (nameArg != null) {
- *     TSNode keyNode = nameArg.getKeyNode();        // Access to key node
- *     TSNode valueNode = nameArg.getValueNode();    // Access to value node
- *     String keyText = nameArg.getKey(tsFile);      // "name"
- *     String valueText = nameArg.getValue(tsFile);  // "\"users\""
- *   }
- * }
- *
- * // Get all argument pairs
- * List&lt;TSNode&gt; argumentPairs = annotationService.getAnnotationArgumentPairs(tsFile, tableAnnotation.get());
- *
- * // Find specific value by key
- * Optional&lt;TSNode&gt; nameValue = annotationService.getAnnotationValueByKey(tsFile, tableAnnotation.get(), "name");
- * </pre>
- *
- * @see TSFile
- * @see AnnotationCapture
- * @see AnnotationArgument
- */
 public class AnnotationService {
 
   /**
@@ -72,8 +21,8 @@ public class AnnotationService {
    *
    * <p>This method searches for all annotation declarations within the specified scope node,
    * including both marker annotations (e.g., {@code @Override}) and annotations with arguments
-   * (e.g., {@code @Table(name = "users")}). The search is performed using tree-sitter queries
-   * to accurately identify annotation nodes at the AST level.
+   * (e.g., {@code @Table(name = "users")}). The search is performed using tree-sitter queries to
+   * accurately identify annotation nodes at the AST level.
    *
    * <p>Usage example:
    *
@@ -543,8 +492,8 @@ public class AnnotationService {
    * @param tsFile The {@link TSFile} containing the Java source code to modify
    * @param declarationNode The declaration node (class, method, or field) to add annotation to
    * @param insertionPoint The {@link AnnotationInsertionPoint} specifying where to insert
-   * @param annotationText The annotation text to insert (e.g., "@Override", "@Entity",
-   *     "@Table(name = \"users\")")
+   * @param annotationText The annotation text to insert (e.g., "@Override", "@Entity", "@Table(name
+   *     = \"users\")")
    */
   public void addAnnotation(
       TSFile tsFile,

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/ClassDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/ClassDeclarationService.java
@@ -14,58 +14,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and manipulating class declarations in Java source code using tree-sitter.
- *
- * <p>This service provides comprehensive functionality for working with class declarations within
- * Java source files, including extraction of class information, finding classes by name, resolving
- * superclass relationships, and performing class-related transformations. It leverages tree-sitter
- * queries to accurately parse and analyze class declarations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting class name, annotations, modifiers, and superclass information
- *   <li>Finding all class declarations within a file
- *   <li>Locating classes by name or file-based public class lookup
- *   <li>Resolving superclass fully qualified names
- *   <li>Checking for local vs external class references
- *   <li>Renaming class declarations and associated files
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * ClassDeclarationService classService = new ClassDeclarationService(fieldService, methodService);
- *
- * // Find a specific class by name
- * Optional&lt;TSNode&gt; classNode = classService.findClassByName(tsFile, "UserService");
- * if (classNode.isPresent()) {
- *   // Get detailed class information
- *   List&lt;Map&lt;String, TSNode&gt;&gt; classInfo = classService.getClassDeclarationNodeInfo(tsFile, classNode.get());
- *   for (Map&lt;String, TSNode&gt; info : classInfo) {
- *     String className = tsFile.getTextFromNode(info.get("className"));
- *     TSNode superclass = info.get("superclass");
- *     if (superclass != null) {
- *       String superclassName = tsFile.getTextFromNode(superclass);
- *       System.out.println("Class " + className + " extends " + superclassName);
- *     }
- *   }
- * }
- *
- * // Find the main public class of a file
- * Optional&lt;TSNode&gt; publicClass = classService.getPublicClass(tsFile);
- * if (publicClass.isPresent()) {
- *   String className = tsFile.getTextFromNode(classService.getClassDeclarationNameNode(tsFile, publicClass.get()).get());
- *   System.out.println("Public class: " + className);
- * }
- * </pre>
- *
- * @see TSFile
- * @see ClassCapture
- * @see FieldDeclarationService
- * @see MethodDeclarationService
- */
 @Getter
 @RequiredArgsConstructor
 public class ClassDeclarationService {
@@ -463,6 +411,4 @@ public class ClassDeclarationService {
             "Short")
         .contains(className);
   }
-
-
 }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/FieldDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/FieldDeclarationService.java
@@ -8,55 +8,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and manipulating field declarations in Java source code using tree-sitter.
- *
- * <p>This service provides comprehensive functionality for working with field declarations within
- * Java classes, including extraction of field information, finding field usages, and performing
- * field-related transformations. It leverages tree-sitter queries to accurately parse and analyze
- * field declarations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting field type, name, and initialization values
- *   <li>Finding all field declarations within a class
- *   <li>Locating field annotations
- *   <li>Searching for field usages across the class
- *   <li>Finding fields by name or type
- *   <li>Renaming field declarations and their usages
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * FieldDeclarationService fieldService = new FieldDeclarationService();
- * ClassDeclarationService classService = new ClassDeclarationService();
- *
- * // Find a class and get all its fields
- * TSNode classNode = classService.findClassByName(tsFile, "User").get();
- * List&lt;TSNode&gt; fieldNodes = fieldService.getAllFieldDeclarationNodes(tsFile, classNode);
- *
- * // Analyze each field
- * for (TSNode fieldNode : fieldNodes) {
- *   List&lt;Map&lt;String, TSNode&gt;&gt; fieldInfo = fieldService.getFieldDeclarationNodeInfo(tsFile, fieldNode);
- *   for (Map&lt;String, TSNode&gt; info : fieldInfo) {
- *     String type = tsFile.getTextFromNode(info.get("fieldType"));
- *     String name = tsFile.getTextFromNode(info.get("fieldName"));
- *     System.out.println("Field: " + type + " " + name);
- *   }
- * }
- * </pre>
- *
- * @see TSFile
- * @see FieldCapture
- */
-@Getter
-@RequiredArgsConstructor
 public class FieldDeclarationService {
 
   /**

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/FormalParameterService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/FormalParameterService.java
@@ -8,44 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and extracting method parameter information from Java source code using
- * Tree-sitter parsing.
- *
- * <p>This service provides comprehensive functionality for working with method (formal) parameters
- * in Java, including extraction of parameter nodes, detailed parameter info, finding usages within
- * method bodies, and renaming parameters. It leverages tree-sitter queries to accurately parse and
- * analyze parameter declarations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting all parameter nodes from a method declaration
- *   <li>Extracting type, name, and full node info for each parameter
- *   <li>Finding all usages of a parameter within a method body
- *   <li>Supporting generic and non-generic parameter types
- *   <li>Renaming parameter declarations and their usages
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * FormalParameterService paramService = new FormalParameterService();
- * TSNode methodNode = ... // obtain method_declaration node
- * List&lt;TSNode&gt; params = paramService.getAllFormalParameterNodes(tsFile, methodNode);
- * for (TSNode param : params) {
- *   List&lt;Map&lt;String, TSNode&gt;&gt; info = paramService.getFormalParameterNodeInfo(tsFile, param);
- *   for (Map&lt;String, TSNode&gt; map : info) {
- *     String type = tsFile.getTextFromNode(map.get("parameter_type"));
- *     String name = tsFile.getTextFromNode(map.get("parameter_name"));
- *     System.out.println("Parameter: " + type + " " + name);
- *   }
- * }
- * </pre>
- *
- * @see TSFile
- * @see ParameterCapture
- */
 public class FormalParameterService {
 
   /**

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/ImportDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/ImportDeclarationService.java
@@ -9,64 +9,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.Getter;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and manipulating import declarations in Java source code using tree-sitter.
- *
- * <p>This service provides comprehensive functionality for working with import declarations within
- * Java source files, including extraction of import information, finding import statements,
- * checking for existing imports, and performing import-related transformations. It leverages
- * tree-sitter queries to accurately parse and analyze import declarations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting import scope, class name, and wildcard information
- *   <li>Finding all import declarations within a file
- *   <li>Locating specific imports by package and class name
- *   <li>Checking for wildcard imports vs specific class imports
- *   <li>Determining optimal insertion points for new imports
- *   <li>Adding and updating import statements
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * ImportDeclarationService importService = new ImportDeclarationService();
- *
- * // Check if a class is already imported
- * boolean imported = importService.isClassImported(tsFile, "java.util", "List");
- * if (!imported) {
- *   // Add the import
- *   TSNode packageNode = packageService.getPackageDeclarationNode(tsFile).orElse(null);
- *   importService.addImport(tsFile, "java.util", "List", packageNode);
- * }
- *
- * // Find all imports in the file
- * List&lt;TSNode&gt; imports = importService.getAllImportDeclarationNodes(tsFile);
- * for (TSNode importNode : imports) {
- *   List&lt;Map&lt;String, TSNode&gt;&gt; info = importService.getImportDeclarationNodeInfo(tsFile, importNode);
- *   for (Map&lt;String, TSNode&gt; infoMap : info) {
- *     TSNode classNode = infoMap.get("class_name");
- *     if (classNode != null) {
- *       String className = tsFile.getTextFromNode(classNode);
- *       System.out.println("Imported class: " + className);
- *     }
- *   }
- * }
- * </pre>
- *
- * @see TSFile
- * @see ImportCapture
- * @see ImportInsertionPoint
- * @see PackageDeclarationService
- */
-@Getter
 public class ImportDeclarationService {
-  private final PackageDeclarationService packageDeclarationService =
-      new PackageDeclarationService();
 
   /**
    * Retrieves all import declaration nodes from the given Java source file.

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/LocalVariableDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/LocalVariableDeclarationService.java
@@ -10,61 +10,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and manipulating local variable declarations, formal parameters, and field
- * declarations in Java source code using tree-sitter.
- *
- * <p>This service provides comprehensive functionality for working with variable declarations of
- * all types within Java source files, including extraction of variable information, finding
- * variable usages, scope analysis, and performing variable-related transformations. It leverages
- * tree-sitter queries to accurately parse and analyze variable declarations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting variable type, name, modifiers, and initialization values
- *   <li>Finding all variable declarations (local, parameters, fields) within a file
- *   <li>Locating variable usages within appropriate scopes
- *   <li>Analyzing generic types and type arguments
- *   <li>Handling scope-based variable resolution and shadowing
- *   <li>Finding type references across different contexts
- * </ul>
- *
- * <p>Variable types supported:
- *
- * <ul>
- *   <li><strong>Local variables:</strong> Variables declared within method bodies or blocks
- *   <li><strong>Formal parameters:</strong> Method and constructor parameters
- *   <li><strong>Field declarations:</strong> Class-level instance and static fields
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * LocalVariableDeclarationService varService = new LocalVariableDeclarationService();
- *
- * // Find all variable declarations in a file
- * List&lt;TSNode&gt; allVars = varService.getAllMethodParameterNodes(tsFile);
- * for (TSNode varNode : allVars) {
- *   List&lt;Map&lt;String, TSNode&gt;&gt; info = varService.getLocalVariableDeclarationNodeInfo(tsFile, varNode);
- *   for (Map&lt;String, TSNode&gt; infoMap : info) {
- *     String type = tsFile.getTextFromNode(infoMap.get("variable_type"));
- *     String name = tsFile.getTextFromNode(infoMap.get("variable_name"));
- *     System.out.println("Variable: " + type + " " + name);
- *   }
- * }
- *
- * // Find all usages of a specific variable
- * List&lt;TSNode&gt; usages = varService.findVariableUsagesInScope(tsFile, varNode);
- * for (TSNode usage : usages) {
- *   int line = usage.getStartPoint().getRow() + 1;
- *   System.out.println("Usage at line: " + line);
- * }
- * </pre>
- *
- * @see TSFile
- * @see VariableCapture
- */
 public class LocalVariableDeclarationService {
   /**
    * Retrieves all variable declaration nodes from a file, including local variables, formal

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/MethodDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/MethodDeclarationService.java
@@ -12,61 +12,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and manipulating method declarations and invocations in Java source code
- * using tree-sitter.
- *
- * <p>This service provides comprehensive functionality for working with method declarations and
- * method invocations within Java source files, including extraction of method information, finding
- * method usages, and performing method-related transformations. It leverages tree-sitter queries to
- * accurately parse and analyze method declarations and invocations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting method name, return type, parameters, and modifiers
- *   <li>Finding all method declarations within a class
- *   <li>Locating method invocations and their components
- *   <li>Identifying special methods like main method
- *   <li>Analyzing method signatures and parameter lists
- *   <li>Finding method usages across different contexts
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * MethodDeclarationService methodService = new MethodDeclarationService(parameterService);
- *
- * // Find all methods in a class
- * TSNode classNode = classService.findClassByName(tsFile, "MyClass").get();
- * List&lt;TSNode&gt; methods = methodService.getAllMethodDeclarationNodes(tsFile, classNode);
- *
- * // Analyze each method
- * for (TSNode methodNode : methods) {
- *   List&lt;Map&lt;String, TSNode&gt;&gt; methodInfo = methodService.getMethodDeclarationNodeInfo(tsFile, methodNode);
- *   for (Map&lt;String, TSNode&gt; info : methodInfo) {
- *     String methodName = tsFile.getTextFromNode(info.get("method_name"));
- *     String returnType = tsFile.getTextFromNode(info.get("method_return_type"));
- *     System.out.println("Method: " + returnType + " " + methodName);
- *   }
- * }
- *
- * // Find method invocations
- * List&lt;TSNode&gt; invocations = methodService.getAllMethodInvocationNodes(tsFile, classNode);
- * for (TSNode invocation : invocations) {
- *   Optional&lt;TSNode&gt; nameNode = methodService.getMethodInvocationNameNode(tsFile, invocation);
- *   if (nameNode.isPresent()) {
- *     String methodName = tsFile.getTextFromNode(nameNode.get());
- *     System.out.println("Method called: " + methodName);
- *   }
- * }
- * </pre>
- *
- * @see TSFile
- * @see MethodCapture
- * @see MethodInvocationCapture
- * @see FormalParameterService
- */
 @Getter
 @RequiredArgsConstructor
 public class MethodDeclarationService {

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/PackageDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/PackageDeclarationService.java
@@ -11,52 +11,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import org.treesitter.TSNode;
 
-/**
- * Service for analyzing and manipulating package declarations in Java source code using tree-sitter.
- *
- * <p>This service provides comprehensive functionality for working with package declarations within
- * Java source files, including extraction of package information, resolving package paths, and
- * performing package-related transformations. It leverages tree-sitter queries to accurately parse
- * and analyze package declarations at the AST level.
- *
- * <p>Key capabilities include:
- *
- * <ul>
- *   <li>Extracting package names and scopes from source files
- *   <li>Finding package declaration nodes
- *   <li>Resolving package paths to file system directories
- *   <li>Determining source directory types (main, test, etc.)
- *   <li>Converting between package names and directory structures
- * </ul>
- *
- * <p>Usage example:
- *
- * <pre>
- * PackageDeclarationService packageService = new PackageDeclarationService();
- *
- * // Get package declaration from a file
- * Optional&lt;TSNode&gt; packageNode = packageService.getPackageDeclarationNode(tsFile);
- * if (packageNode.isPresent()) {
- *   List&lt;Map&lt;String, TSNode&gt;&gt; info = packageService.getPackageDeclarationInfo(tsFile, packageNode.get());
- *   for (Map&lt;String, TSNode&gt; infoMap : info) {
- *     String packageName = tsFile.getTextFromNode(infoMap.get("package_scope"));
- *     System.out.println("Package: " + packageName);
- *   }
- * }
- *
- * // Resolve package path
- * Path packagePath = packageService.resolvePackagePath(projectRoot, "com.example.service");
- * System.out.println("Package directory: " + packagePath);
- * </pre>
- *
- * @see TSFile
- * @see PackageCapture
- * @see JavaSourceDirectoryType
- */
+@RequiredArgsConstructor
 public class PackageDeclarationService {
-  private final PathHelper pathHelper = new PathHelper();
+  private final PathHelper pathHelper;
 
   /**
    * Gets the package declaration node from a Java file.
@@ -166,12 +126,14 @@ public class PackageDeclarationService {
   }
 
   /**
-   * Resolves the file system path for a given package scope within the specified source directory type.
+   * Resolves the file system path for a given package scope within the specified source directory
+   * type.
    *
-   * <p>This method finds the appropriate source directory (main or test), converts the package scope
-   * (e.g., "com.example.foo") to a directory path, and ensures the directory exists.
+   * <p>This method finds the appropriate source directory (main or test), converts the package
+   * scope (e.g., "com.example.foo") to a directory path, and ensures the directory exists.
    *
    * <p>Usage example:
+   *
    * <pre>
    * Optional<Path> packageDir = service.getFilePathFromPackageScope(
    *     projectRoot, "com.example.foo", JavaSourceDirectoryType.MAIN);
@@ -183,7 +145,8 @@ public class PackageDeclarationService {
    * @param rootDir The root directory of the project.
    * @param packageScope The package scope as a dot-separated string (e.g., "com.example.foo").
    * @param sourceDirectoryType The type of source directory (main or test).
-   * @return An {@link Optional} containing the resolved package directory path, or empty if not found or on error.
+   * @return An {@link Optional} containing the resolved package directory path, or empty if not
+   *     found or on error.
    */
   public Optional<Path> getFilePathFromPackageScope(
       Path rootDir, String packageScope, JavaSourceDirectoryType sourceDirectoryType) {

--- a/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
@@ -54,7 +54,8 @@ class JavaLanguageServiceTest {
         new MethodDeclarationService(formalParameterService);
     ClassDeclarationService classDeclarationService =
         new ClassDeclarationService(fieldDeclarationService, methodDeclarationService);
-    PackageDeclarationService packageDeclarationService = new PackageDeclarationService();
+    PackageDeclarationService packageDeclarationService =
+        new PackageDeclarationService(this.pathHelper);
     ImportDeclarationService importDeclarationService = new ImportDeclarationService();
     LocalVariableDeclarationService localVariableDeclarationService =
         new LocalVariableDeclarationService();
@@ -862,4 +863,3 @@ class JavaLanguageServiceTest {
     }
   }
 }
-

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/ImportDeclarationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/ImportDeclarationServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.java.language.extra.ImportCapture;
+import io.github.syntaxpresso.core.util.PathHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,7 +24,7 @@ import org.treesitter.TSNode;
 class ImportDeclarationServiceTest {
 
   private static final String JAVA_WITH_IMPORTS =
-      """
+"""
 package com.example;
 
 import java.util.List;
@@ -31,7 +32,7 @@ import java.util.Map;
 import java.util.Set;
 """;
   private static final String JAVA_WITH_WILDCARD_IMPORTS =
-      """
+"""
 package com.example;
 
 import java.util.*;
@@ -39,9 +40,10 @@ import java.util.*;
   private static final String JAVA_NO_IMPORTS = "package com.example;";
   private static final String JAVA_NO_PACKAGE_NO_IMPORTS = "class Test {}";
   private static final String JAVA_NO_PACKAGE_WITH_IMPORTS =
-      """
+"""
 import java.util.List;
-class Test {}""";
+class Test {}\
+""";
 
   @TempDir Path tempDir;
   private ImportDeclarationService service;
@@ -90,13 +92,15 @@ class Test {}""";
       assertFalse(info.isEmpty());
       assertEquals(
           "java.util.List",
-          tsFile.getTextFromNode(info.get(0).get(ImportCapture.FULL_IMPORT_SCOPE.getCaptureName())));
+          tsFile.getTextFromNode(
+              info.get(0).get(ImportCapture.FULL_IMPORT_SCOPE.getCaptureName())));
       assertEquals(
           "java.util",
           tsFile.getTextFromNode(
               info.get(1).get(ImportCapture.RELATIVE_IMPORT_SCOPE.getCaptureName())));
       assertEquals(
-          "List", tsFile.getTextFromNode(info.get(1).get(ImportCapture.CLASS_NAME.getCaptureName())));
+          "List",
+          tsFile.getTextFromNode(info.get(1).get(ImportCapture.CLASS_NAME.getCaptureName())));
     }
 
     @Test
@@ -108,7 +112,8 @@ class Test {}""";
       assertFalse(info.isEmpty());
       assertEquals(
           "java.util",
-          tsFile.getTextFromNode(info.get(0).get(ImportCapture.FULL_IMPORT_SCOPE.getCaptureName())));
+          tsFile.getTextFromNode(
+              info.get(0).get(ImportCapture.FULL_IMPORT_SCOPE.getCaptureName())));
       assertTrue(info.get(1).containsKey(ImportCapture.ASTERISK.getCaptureName()));
     }
   }
@@ -169,12 +174,16 @@ class Test {}""";
   @Nested
   @DisplayName("addImport()")
   class AddImport {
+    private final PathHelper pathHelper = new PathHelper();
+
     @Test
     @DisplayName("should add import after package when no imports exist")
     void shouldAddImportAfterPackageWhenNoImportsExist() throws IOException {
       tsFile = createTempTSFile(JAVA_NO_IMPORTS);
       TSNode packageNode =
-          new PackageDeclarationService().getPackageDeclarationNode(tsFile).orElse(null);
+          new PackageDeclarationService(this.pathHelper)
+              .getPackageDeclarationNode(tsFile)
+              .orElse(null);
       service.addImport(tsFile, "java.util", "List", packageNode);
       String expected = "package com.example;\n\nimport java.util.List;";
       assertEquals(expected, tsFile.getSourceCode());
@@ -194,7 +203,9 @@ class Test {}""";
     void shouldAddImportAfterExistingImports() throws IOException {
       tsFile = createTempTSFile(JAVA_NO_PACKAGE_WITH_IMPORTS);
       TSNode packageNode =
-          new PackageDeclarationService().getPackageDeclarationNode(tsFile).orElse(null);
+          new PackageDeclarationService(this.pathHelper)
+              .getPackageDeclarationNode(tsFile)
+              .orElse(null);
       service.addImport(tsFile, "java.util", "Map", packageNode);
       String expected = "import java.util.List;\nimport java.util.Map;";
       assertTrue(tsFile.getSourceCode().contains(expected));
@@ -206,7 +217,9 @@ class Test {}""";
       tsFile = createTempTSFile(JAVA_WITH_IMPORTS);
       String originalSource = tsFile.getSourceCode();
       TSNode packageNode =
-          new PackageDeclarationService().getPackageDeclarationNode(tsFile).orElse(null);
+          new PackageDeclarationService(this.pathHelper)
+              .getPackageDeclarationNode(tsFile)
+              .orElse(null);
       service.addImport(tsFile, "java.util", "List", packageNode);
       assertEquals(originalSource, tsFile.getSourceCode());
     }
@@ -219,8 +232,7 @@ class Test {}""";
     @DisplayName("should update an existing import")
     void shouldUpdateAnExistingImport() throws IOException {
       tsFile = createTempTSFile(JAVA_WITH_IMPORTS);
-      boolean updated =
-          service.updateImport(tsFile, "java.util", "java.awt", "List", "Button");
+      boolean updated = service.updateImport(tsFile, "java.util", "java.awt", "List", "Button");
       assertTrue(updated);
       assertTrue(tsFile.getSourceCode().contains("import java.awt.Button;"));
       assertFalse(tsFile.getSourceCode().contains("import java.util.List;"));

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/PackageDeclarationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/PackageDeclarationServiceTest.java
@@ -9,6 +9,7 @@ import io.github.syntaxpresso.core.command.extra.JavaSourceDirectoryType;
 import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.java.language.extra.PackageCapture;
+import io.github.syntaxpresso.core.util.PathHelper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,6 +26,7 @@ import org.treesitter.TSNode;
 @DisplayName("PackageDeclarationService Tests")
 class PackageDeclarationServiceTest {
   private PackageDeclarationService packageDeclarationService;
+  private PathHelper pathHelper;
 
   private static final String SIMPLE_PACKAGE_CODE =
       """
@@ -74,7 +76,8 @@ class PackageDeclarationServiceTest {
 
   @BeforeEach
   void setUp() {
-    this.packageDeclarationService = new PackageDeclarationService();
+    this.pathHelper = new PathHelper();
+    this.packageDeclarationService = new PackageDeclarationService(this.pathHelper);
   }
 
   @Nested
@@ -182,12 +185,12 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      List<Map<String, TSNode>> packageInfo = 
+      List<Map<String, TSNode>> packageInfo =
           packageDeclarationService.getPackageDeclarationInfo(tsFile, packageNode.get());
 
       assertFalse(packageInfo.isEmpty());
       Map<String, TSNode> info = packageInfo.get(0);
-      
+
       TSNode packageScopeNode = info.get(PackageCapture.PACKAGE_SCOPE.getCaptureName());
       assertNotNull(packageScopeNode);
       assertEquals("com.example.service", tsFile.getTextFromNode(packageScopeNode));
@@ -207,12 +210,12 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, NESTED_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      List<Map<String, TSNode>> packageInfo = 
+      List<Map<String, TSNode>> packageInfo =
           packageDeclarationService.getPackageDeclarationInfo(tsFile, packageNode.get());
 
       assertFalse(packageInfo.isEmpty());
       Map<String, TSNode> info = packageInfo.get(0);
-      
+
       TSNode packageScopeNode = info.get(PackageCapture.PACKAGE_SCOPE.getCaptureName());
       assertNotNull(packageScopeNode);
       assertEquals("com.example.project.service.impl", tsFile.getTextFromNode(packageScopeNode));
@@ -232,7 +235,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      List<Map<String, TSNode>> packageInfo = 
+      List<Map<String, TSNode>> packageInfo =
           packageDeclarationService.getPackageDeclarationInfo(null, packageNode.get());
 
       assertTrue(packageInfo.isEmpty());
@@ -244,7 +247,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       TSNode invalidNode = tsFile.query("(identifier) @id").returning("id").execute().firstNode();
 
-      List<Map<String, TSNode>> packageInfo = 
+      List<Map<String, TSNode>> packageInfo =
           packageDeclarationService.getPackageDeclarationInfo(tsFile, invalidNode);
 
       assertTrue(packageInfo.isEmpty());
@@ -273,7 +276,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> classNameNode = 
+      Optional<TSNode> classNameNode =
           packageDeclarationService.getPackageClassNameNode(tsFile, packageNode.get());
 
       assertTrue(classNameNode.isPresent());
@@ -286,7 +289,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, NESTED_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> classNameNode = 
+      Optional<TSNode> classNameNode =
           packageDeclarationService.getPackageClassNameNode(tsFile, packageNode.get());
 
       assertTrue(classNameNode.isPresent());
@@ -299,7 +302,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> classNameNode = 
+      Optional<TSNode> classNameNode =
           packageDeclarationService.getPackageClassNameNode(null, packageNode.get());
 
       assertFalse(classNameNode.isPresent());
@@ -311,7 +314,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       TSNode invalidNode = tsFile.query("(identifier) @id").returning("id").execute().firstNode();
 
-      Optional<TSNode> classNameNode = 
+      Optional<TSNode> classNameNode =
           packageDeclarationService.getPackageClassNameNode(tsFile, invalidNode);
 
       assertFalse(classNameNode.isPresent());
@@ -340,7 +343,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> classScopeNode = 
+      Optional<TSNode> classScopeNode =
           packageDeclarationService.getPackageClassScopeNode(tsFile, packageNode.get());
 
       assertTrue(classScopeNode.isPresent());
@@ -353,7 +356,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, NESTED_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> classScopeNode = 
+      Optional<TSNode> classScopeNode =
           packageDeclarationService.getPackageClassScopeNode(tsFile, packageNode.get());
 
       assertTrue(classScopeNode.isPresent());
@@ -366,7 +369,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> classScopeNode = 
+      Optional<TSNode> classScopeNode =
           packageDeclarationService.getPackageClassScopeNode(null, packageNode.get());
 
       assertFalse(classScopeNode.isPresent());
@@ -378,7 +381,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       TSNode invalidNode = tsFile.query("(identifier) @id").returning("id").execute().firstNode();
 
-      Optional<TSNode> classScopeNode = 
+      Optional<TSNode> classScopeNode =
           packageDeclarationService.getPackageClassScopeNode(tsFile, invalidNode);
 
       assertFalse(classScopeNode.isPresent());
@@ -407,7 +410,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> packageScopeNode = 
+      Optional<TSNode> packageScopeNode =
           packageDeclarationService.getPackageScopeNode(tsFile, packageNode.get());
 
       assertTrue(packageScopeNode.isPresent());
@@ -420,11 +423,12 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, NESTED_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> packageScopeNode = 
+      Optional<TSNode> packageScopeNode =
           packageDeclarationService.getPackageScopeNode(tsFile, packageNode.get());
 
       assertTrue(packageScopeNode.isPresent());
-      assertEquals("com.example.project.service.impl", tsFile.getTextFromNode(packageScopeNode.get()));
+      assertEquals(
+          "com.example.project.service.impl", tsFile.getTextFromNode(packageScopeNode.get()));
     }
 
     @Test
@@ -433,7 +437,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
-      Optional<TSNode> packageScopeNode = 
+      Optional<TSNode> packageScopeNode =
           packageDeclarationService.getPackageScopeNode(null, packageNode.get());
 
       assertFalse(packageScopeNode.isPresent());
@@ -445,7 +449,7 @@ class PackageDeclarationServiceTest {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       TSNode invalidNode = tsFile.query("(identifier) @id").returning("id").execute().firstNode();
 
-      Optional<TSNode> packageScopeNode = 
+      Optional<TSNode> packageScopeNode =
           packageDeclarationService.getPackageScopeNode(tsFile, invalidNode);
 
       assertFalse(packageScopeNode.isPresent());
@@ -456,8 +460,7 @@ class PackageDeclarationServiceTest {
   @DisplayName("getFilePathFromPackageScope() Tests")
   class GetFilePathFromPackageScopeTests {
 
-    @TempDir
-    Path tempDir;
+    @TempDir Path tempDir;
 
     /**
      * Tests that getFilePathFromPackageScope resolves package paths correctly.
@@ -475,11 +478,13 @@ class PackageDeclarationServiceTest {
      */
     @Test
     @DisplayName("should resolve package path for main source directory")
-    void getFilePathFromPackageScope_withMainSourceType_shouldResolveCorrectly() throws IOException {
+    void getFilePathFromPackageScope_withMainSourceType_shouldResolveCorrectly()
+        throws IOException {
       String packageScope = "com.example.service";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, packageScope, JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              tempDir, packageScope, JavaSourceDirectoryType.MAIN);
 
       assertTrue(packagePath.isPresent());
       assertTrue(Files.exists(packagePath.get()));
@@ -489,11 +494,13 @@ class PackageDeclarationServiceTest {
 
     @Test
     @DisplayName("should resolve package path for test source directory")
-    void getFilePathFromPackageScope_withTestSourceType_shouldResolveCorrectly() throws IOException {
+    void getFilePathFromPackageScope_withTestSourceType_shouldResolveCorrectly()
+        throws IOException {
       String packageScope = "com.example.test";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, packageScope, JavaSourceDirectoryType.TEST);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              tempDir, packageScope, JavaSourceDirectoryType.TEST);
 
       assertTrue(packagePath.isPresent());
       assertTrue(Files.exists(packagePath.get()));
@@ -503,11 +510,13 @@ class PackageDeclarationServiceTest {
 
     @Test
     @DisplayName("should resolve single level package path")
-    void getFilePathFromPackageScope_withSingleLevelPackage_shouldResolveCorrectly() throws IOException {
+    void getFilePathFromPackageScope_withSingleLevelPackage_shouldResolveCorrectly()
+        throws IOException {
       String packageScope = "service";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, packageScope, JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              tempDir, packageScope, JavaSourceDirectoryType.MAIN);
 
       assertTrue(packagePath.isPresent());
       assertTrue(Files.exists(packagePath.get()));
@@ -516,15 +525,17 @@ class PackageDeclarationServiceTest {
 
     @Test
     @DisplayName("should find existing source directory")
-    void getFilePathFromPackageScope_withExistingSourceDir_shouldUseExistingDir() throws IOException {
+    void getFilePathFromPackageScope_withExistingSourceDir_shouldUseExistingDir()
+        throws IOException {
       // Create existing source directory
       Path existingSourceDir = tempDir.resolve("src/main/java");
       Files.createDirectories(existingSourceDir);
 
       String packageScope = "com.example.existing";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, packageScope, JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              tempDir, packageScope, JavaSourceDirectoryType.MAIN);
 
       assertTrue(packagePath.isPresent());
       assertTrue(Files.exists(packagePath.get()));
@@ -537,8 +548,9 @@ class PackageDeclarationServiceTest {
     void getFilePathFromPackageScope_withNullRootDir_shouldReturnEmpty() {
       String packageScope = "com.example.service";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          null, packageScope, JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              null, packageScope, JavaSourceDirectoryType.MAIN);
 
       assertFalse(packagePath.isPresent());
     }
@@ -551,8 +563,9 @@ class PackageDeclarationServiceTest {
 
       String packageScope = "com.example.service";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          fileInsteadOfDir, packageScope, JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              fileInsteadOfDir, packageScope, JavaSourceDirectoryType.MAIN);
 
       assertFalse(packagePath.isPresent());
     }
@@ -560,8 +573,9 @@ class PackageDeclarationServiceTest {
     @Test
     @DisplayName("should return empty for null package scope")
     void getFilePathFromPackageScope_withNullPackageScope_shouldReturnEmpty() {
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, null, JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              tempDir, null, JavaSourceDirectoryType.MAIN);
 
       assertFalse(packagePath.isPresent());
     }
@@ -569,8 +583,9 @@ class PackageDeclarationServiceTest {
     @Test
     @DisplayName("should return empty for blank package scope")
     void getFilePathFromPackageScope_withBlankPackageScope_shouldReturnEmpty() {
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, "   ", JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              tempDir, "   ", JavaSourceDirectoryType.MAIN);
 
       assertFalse(packagePath.isPresent());
     }
@@ -580,19 +595,21 @@ class PackageDeclarationServiceTest {
     void getFilePathFromPackageScope_withNullSourceDirectoryType_shouldReturnEmpty() {
       String packageScope = "com.example.service";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, packageScope, null);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(tempDir, packageScope, null);
 
       assertFalse(packagePath.isPresent());
     }
 
     @Test
     @DisplayName("should handle nested package directories")
-    void getFilePathFromPackageScope_withDeeplyNestedPackage_shouldResolveCorrectly() throws IOException {
+    void getFilePathFromPackageScope_withDeeplyNestedPackage_shouldResolveCorrectly()
+        throws IOException {
       String packageScope = "com.example.project.service.impl.utils";
 
-      Optional<Path> packagePath = packageDeclarationService.getFilePathFromPackageScope(
-          tempDir, packageScope, JavaSourceDirectoryType.MAIN);
+      Optional<Path> packagePath =
+          packageDeclarationService.getFilePathFromPackageScope(
+              tempDir, packageScope, JavaSourceDirectoryType.MAIN);
 
       assertTrue(packagePath.isPresent());
       assertTrue(Files.exists(packagePath.get()));
@@ -608,9 +625,9 @@ class PackageDeclarationServiceTest {
     @DisplayName("should handle malformed source code")
     void methods_withMalformedCode_shouldHandleGracefully() {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MALFORMED_CODE);
-      
+
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
-      
+
       // Should not crash, behavior may vary based on tree-sitter parsing
       assertNotNull(packageNode);
     }
@@ -619,9 +636,9 @@ class PackageDeclarationServiceTest {
     @DisplayName("should handle empty source code")
     void methods_withEmptyCode_shouldHandleGracefully() {
       TSFile tsFile = new TSFile(SupportedLanguage.JAVA, "");
-      
+
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
-      
+
       assertFalse(packageNode.isPresent());
     }
 
@@ -632,10 +649,10 @@ class PackageDeclarationServiceTest {
       Optional<TSNode> packageNode = packageDeclarationService.getPackageDeclarationNode(tsFile);
 
       assertTrue(packageNode.isPresent());
-      
-      List<Map<String, TSNode>> packageInfo = 
+
+      List<Map<String, TSNode>> packageInfo =
           packageDeclarationService.getPackageDeclarationInfo(tsFile, packageNode.get());
-      
+
       // Single level packages may not have scope/name separation
       assertNotNull(packageInfo);
     }
@@ -645,23 +662,30 @@ class PackageDeclarationServiceTest {
     void methods_withInvalidInput_shouldHandleGracefully() {
       TSFile validFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_PACKAGE_CODE);
       TSFile invalidFile = new TSFile(SupportedLanguage.JAVA, "");
-      TSNode invalidNode = validFile.query("(identifier) @id").returning("id").execute().firstNode();
+      TSNode invalidNode =
+          validFile.query("(identifier) @id").returning("id").execute().firstNode();
 
       // Test all methods with invalid combinations
       assertFalse(packageDeclarationService.getPackageDeclarationNode(null).isPresent());
       assertFalse(packageDeclarationService.getPackageDeclarationNode(invalidFile).isPresent());
-      
+
       assertTrue(packageDeclarationService.getPackageDeclarationInfo(null, invalidNode).isEmpty());
-      assertTrue(packageDeclarationService.getPackageDeclarationInfo(validFile, invalidNode).isEmpty());
-      
+      assertTrue(
+          packageDeclarationService.getPackageDeclarationInfo(validFile, invalidNode).isEmpty());
+
       assertFalse(packageDeclarationService.getPackageClassNameNode(null, invalidNode).isPresent());
-      assertFalse(packageDeclarationService.getPackageClassNameNode(validFile, invalidNode).isPresent());
-      
-      assertFalse(packageDeclarationService.getPackageClassScopeNode(null, invalidNode).isPresent());
-      assertFalse(packageDeclarationService.getPackageClassScopeNode(validFile, invalidNode).isPresent());
-      
+      assertFalse(
+          packageDeclarationService.getPackageClassNameNode(validFile, invalidNode).isPresent());
+
+      assertFalse(
+          packageDeclarationService.getPackageClassScopeNode(null, invalidNode).isPresent());
+      assertFalse(
+          packageDeclarationService.getPackageClassScopeNode(validFile, invalidNode).isPresent());
+
       assertFalse(packageDeclarationService.getPackageScopeNode(null, invalidNode).isPresent());
-      assertFalse(packageDeclarationService.getPackageScopeNode(validFile, invalidNode).isPresent());
+      assertFalse(
+          packageDeclarationService.getPackageScopeNode(validFile, invalidNode).isPresent());
     }
   }
 }
+


### PR DESCRIPTION
- Remove comprehensive JavaDoc from service classes for cleaner code
- Refactor PackageDeclarationService to use dependency injection for PathHelper
- Remove redundant PackageDeclarationService field from ImportDeclarationService
- Update Core.java to provide PathHelper to PackageDeclarationService
- Fix test files to accommodate constructor changes
- Clean up unused Lombok annotations