### PR TITLE
ci: run develop branch checks only for PRs, not post-merge

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -3,9 +3,6 @@ name: Develop Branch CI
 
 # Controls when the workflow will run
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
- Remove push trigger for develop branch from CI workflow
- Keep pull_request trigger to validate PRs before merge
- Eliminates redundant test and native binary builds after merge
- Maintains thorough PR validation while reducing CI resource usage