### PR TITLE
Fix annotation service

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/Core.java
+++ b/src/main/java/io/github/syntaxpresso/core/Core.java
@@ -13,6 +13,7 @@ import io.github.syntaxpresso.core.service.java.command.GetCursorPositionInfoCom
 import io.github.syntaxpresso.core.service.java.command.GetMainClassCommandService;
 import io.github.syntaxpresso.core.service.java.command.ParseSourceCodeCommandService;
 import io.github.syntaxpresso.core.service.java.command.RenameCommandService;
+import io.github.syntaxpresso.core.service.java.language.AnnotationService;
 import io.github.syntaxpresso.core.service.java.language.ClassDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.FieldDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.FormalParameterService;
@@ -85,6 +86,7 @@ public class Core {
     ImportDeclarationService importDeclarationService = new ImportDeclarationService();
     LocalVariableDeclarationService localVariableDeclarationService =
         new LocalVariableDeclarationService();
+    AnnotationService annotationService = new AnnotationService();
     JavaLanguageService javaLanguageService =
         new JavaLanguageService(
             pathHelper,
@@ -92,7 +94,8 @@ public class Core {
             classDeclarationService,
             packageDeclarationService,
             importDeclarationService,
-            localVariableDeclarationService);
+            localVariableDeclarationService,
+            annotationService);
     RenameCommandService renameCommandService =
         new RenameCommandService(variableNamingService, javaLanguageService);
     GetMainClassCommandService getMainClassCommandService =

--- a/src/main/java/io/github/syntaxpresso/core/service/java/JavaLanguageService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/JavaLanguageService.java
@@ -4,6 +4,7 @@ import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.common.extra.SupportedIDE;
 import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.extra.JavaIdentifierType;
+import io.github.syntaxpresso.core.service.java.language.AnnotationService;
 import io.github.syntaxpresso.core.service.java.language.ClassDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.ImportDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.LocalVariableDeclarationService;
@@ -26,6 +27,7 @@ public class JavaLanguageService {
   private final PackageDeclarationService packageDeclarationService;
   private final ImportDeclarationService importDeclarationService;
   private final LocalVariableDeclarationService localVariableDeclarationService;
+  private final AnnotationService annotationService;
 
   /**
    * Gets all Java files from the current working directory.

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
@@ -442,7 +442,11 @@ public class AnnotationService {
         annotationInsertionPoint.setInsertByte(declarationNode.getStartByte());
       }
     } else {
-      annotationInsertionPoint.setInsertByte(declarationNode.getStartByte());
+      if (allAnnotations.size() == 0) {
+        annotationInsertionPoint.setInsertByte(declarationNode.getStartByte());
+      } else {
+        annotationInsertionPoint.setInsertByte(allAnnotations.getLast().getEndByte());
+      }
     }
     return annotationInsertionPoint;
   }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
@@ -1,5 +1,6 @@
 package io.github.syntaxpresso.core.service.java.language;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Strings;
 import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.service.java.language.extra.AnnotationArgument;
@@ -421,6 +422,7 @@ public class AnnotationService {
    * @param insertionPoint The desired insertion position strategy
    * @return {@link AnnotationInsertionPoint} containing position details, or null if invalid input
    */
+  @Beta
   public AnnotationInsertionPoint getAnnotationInsertionPosition(
       TSFile tsFile, TSNode declarationNode, AnnotationInsertionPosition insertionPoint) {
     if (tsFile == null || tsFile.getTree() == null || declarationNode == null) {
@@ -445,6 +447,7 @@ public class AnnotationService {
       if (allAnnotations.size() == 0) {
         annotationInsertionPoint.setInsertByte(declarationNode.getStartByte());
       } else {
+        annotationInsertionPoint.setBreakLineBefore(true);
         annotationInsertionPoint.setInsertByte(allAnnotations.getLast().getEndByte());
       }
     }
@@ -518,6 +521,9 @@ public class AnnotationService {
       return;
     }
     String insertText = annotationText + "\n";
+    if (insertionPoint.isBreakLineBefore()) {
+      insertText = "\n" + insertText;
+    }
     tsFile.updateSourceCode(
         insertionPoint.getInsertByte(), insertionPoint.getInsertByte(), insertText);
   }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/extra/AnnotationInsertionPoint.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/extra/AnnotationInsertionPoint.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 @Data
 public class AnnotationInsertionPoint {
+  private boolean breakLineBefore = false;
 
   /** Defines the possible insertion points for an annotation statement. */
   public enum AnnotationInsertionPosition {

--- a/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
@@ -10,6 +10,7 @@ import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.common.extra.SupportedIDE;
 import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.extra.JavaIdentifierType;
+import io.github.syntaxpresso.core.service.java.language.AnnotationService;
 import io.github.syntaxpresso.core.service.java.language.ClassDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.FieldDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.FormalParameterService;
@@ -59,6 +60,7 @@ class JavaLanguageServiceTest {
     ImportDeclarationService importDeclarationService = new ImportDeclarationService();
     LocalVariableDeclarationService localVariableDeclarationService =
         new LocalVariableDeclarationService();
+    AnnotationService annotationService = new AnnotationService();
 
     this.javaLanguageService =
         new JavaLanguageService(
@@ -67,7 +69,8 @@ class JavaLanguageServiceTest {
             classDeclarationService,
             packageDeclarationService,
             importDeclarationService,
-            localVariableDeclarationService);
+            localVariableDeclarationService,
+            annotationService);
   }
 
   @Nested


### PR DESCRIPTION
This pull request introduces support for annotation handling in the Java language services by integrating the new `AnnotationService` throughout the codebase. The changes ensure that annotation insertion points are determined more accurately and that the service is properly initialized and tested.

**Integration of annotation support:**

* Added `AnnotationService` as a dependency to `JavaLanguageService` and updated its instantiation in both `Core` and test setup, allowing annotation-related features to be used throughout the application. [[1]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R16) [[2]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R89-R98) [[3]](diffhunk://#diff-4e06ae448ab5b48fc994662360f4f72dc9947e24630a64069b15619cb9f5d635R7) [[4]](diffhunk://#diff-4e06ae448ab5b48fc994662360f4f72dc9947e24630a64069b15619cb9f5d635R30) [[5]](diffhunk://#diff-8db5321f5c59f97a44feb847041f3fb0e835be999f894ab457f207281ae75637R13) [[6]](diffhunk://#diff-8db5321f5c59f97a44feb847041f3fb0e835be999f894ab457f207281ae75637R63) [[7]](diffhunk://#diff-8db5321f5c59f97a44feb847041f3fb0e835be999f894ab457f207281ae75637L70-R73)

**Enhancements to annotation insertion logic:**

* Improved the logic in `AnnotationService#getAnnotationInsertionPosition` to handle cases where there are no existing annotations by inserting at the declaration start, or after the last annotation if present.