### PR TITLE
Correctly handle line breaks during annotation insertion

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
@@ -1,6 +1,5 @@
 package io.github.syntaxpresso.core.service.java.language;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Strings;
 import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.service.java.language.extra.AnnotationArgument;
@@ -422,7 +421,6 @@ public class AnnotationService {
    * @param insertionPoint The desired insertion position strategy
    * @return {@link AnnotationInsertionPoint} containing position details, or null if invalid input
    */
-  @Beta
   public AnnotationInsertionPoint getAnnotationInsertionPosition(
       TSFile tsFile, TSNode declarationNode, AnnotationInsertionPosition insertionPoint) {
     if (tsFile == null || tsFile.getTree() == null || declarationNode == null) {
@@ -439,12 +437,15 @@ public class AnnotationService {
     annotationInsertionPoint.setPosition(insertionPoint);
     if (insertionPoint.equals(AnnotationInsertionPosition.BEFORE_FIRST_ANNOTATION)) {
       if (!allAnnotations.isEmpty()) {
+        annotationInsertionPoint.setBreakLineAfter(true);
         annotationInsertionPoint.setInsertByte(allAnnotations.get(0).getStartByte());
       } else {
+        annotationInsertionPoint.setBreakLineAfter(true);
         annotationInsertionPoint.setInsertByte(declarationNode.getStartByte());
       }
     } else {
       if (allAnnotations.size() == 0) {
+        annotationInsertionPoint.setBreakLineAfter(true);
         annotationInsertionPoint.setInsertByte(declarationNode.getStartByte());
       } else {
         annotationInsertionPoint.setBreakLineBefore(true);
@@ -520,9 +521,12 @@ public class AnnotationService {
         && !nodeType.equals("method_declaration")) {
       return;
     }
-    String insertText = annotationText + "\n";
+    String insertText = annotationText;
     if (insertionPoint.isBreakLineBefore()) {
       insertText = "\n" + insertText;
+    }
+    if (insertionPoint.isBreakLineAfter()) {
+      insertText = annotationText + "\n";
     }
     tsFile.updateSourceCode(
         insertionPoint.getInsertByte(), insertionPoint.getInsertByte(), insertText);

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/extra/AnnotationInsertionPoint.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/extra/AnnotationInsertionPoint.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class AnnotationInsertionPoint {
   private boolean breakLineBefore = false;
+  private boolean breakLineAfter = false;
 
   /** Defines the possible insertion points for an annotation statement. */
   public enum AnnotationInsertionPosition {


### PR DESCRIPTION
This pull request refines the annotation insertion logic in the `AnnotationService` to provide more granular control over line breaks before and after inserted annotations. The changes introduce a new `breakLineAfter` property and update the insertion logic to use it, ensuring that annotations are inserted with the correct formatting.

**Enhancements to annotation insertion formatting:**

* Added a `breakLineAfter` property to `AnnotationInsertionPoint` to allow specifying whether a newline should be added after an inserted annotation.
* Updated `getAnnotationInsertionPosition` to set `breakLineAfter` appropriately based on the insertion context, ensuring new annotations are formatted correctly when inserted before existing annotations or when none exist.
* Modified `addAnnotation` to use both `breakLineBefore` and `breakLineAfter` flags for precise control over annotation formatting, replacing the previous approach of always appending a newline.

**Code cleanup:**

* Removed the unused `@Beta` annotation from the `getAnnotationInsertionPosition` method for clarity. [[1]](diffhunk://#diff-172699c90ea2ca0c1663d8dda094ef8bc1bf4d6d14785d9d4ce2ce4db03576f2L3) [[2]](diffhunk://#diff-172699c90ea2ca0c1663d8dda094ef8bc1bf4d6d14785d9d4ce2ce4db03576f2L425)