### PR TITLE
Create command to create jpa repository for jpa entities

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/Core.java
+++ b/src/main/java/io/github/syntaxpresso/core/Core.java
@@ -73,6 +73,7 @@ public class Core {
     FieldDeclarationService fieldDeclarationService = new FieldDeclarationService();
     ClassDeclarationService classDeclarationService =
         new ClassDeclarationService(fieldDeclarationService, methodDeclarationService);
+    InterfaceDeclarationService interfaceDeclarationService = new InterfaceDeclarationService();
     PackageDeclarationService packageDeclarationService = new PackageDeclarationService(pathHelper);
     ImportDeclarationService importDeclarationService = new ImportDeclarationService();
     LocalVariableDeclarationService localVariableDeclarationService =
@@ -83,6 +84,7 @@ public class Core {
             pathHelper,
             variableNamingService,
             classDeclarationService,
+            interfaceDeclarationService,
             packageDeclarationService,
             importDeclarationService,
             localVariableDeclarationService,
@@ -100,7 +102,7 @@ public class Core {
     CreateNewJPAEntityCommandService createNewJPAEntityCommandService =
         new CreateNewJPAEntityCommandService(javaLanguageService, createNewFileCommandService);
     CreateJPARepositoryCommandService createJPARepositoryCommandService =
-        new CreateJPARepositoryCommandService(javaLanguageService);
+        new CreateJPARepositoryCommandService(javaLanguageService, createNewFileCommandService);
     return new CommandFactory(
         renameCommandService,
         getMainClassCommandService,

--- a/src/main/java/io/github/syntaxpresso/core/Core.java
+++ b/src/main/java/io/github/syntaxpresso/core/Core.java
@@ -1,12 +1,12 @@
 package io.github.syntaxpresso.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.syntaxpresso.core.command.*;
 import io.github.syntaxpresso.core.command.CreateNewFileCommand;
 import io.github.syntaxpresso.core.command.GetCursorPositionInfoCommand;
 import io.github.syntaxpresso.core.command.GetMainClassCommand;
 import io.github.syntaxpresso.core.command.ParseSourceCodeCommand;
 import io.github.syntaxpresso.core.command.RenameCommand;
-import io.github.syntaxpresso.core.command.*;
 import io.github.syntaxpresso.core.common.CommandFactory;
 import io.github.syntaxpresso.core.service.java.JavaLanguageService;
 import io.github.syntaxpresso.core.service.java.command.*;
@@ -23,7 +23,8 @@ import picocli.CommandLine.Command;
       CreateNewFileCommand.class,
       GetCursorPositionInfoCommand.class,
       ParseSourceCodeCommand.class,
-      CreateNewJPAEntityCommand.class
+      CreateNewJPAEntityCommand.class,
+      CreateJPARepositoryCommand.class
     })
 public class Core {
 
@@ -98,12 +99,15 @@ public class Core {
         new ParseSourceCodeCommandService();
     CreateNewJPAEntityCommandService createNewJPAEntityCommandService =
         new CreateNewJPAEntityCommandService(javaLanguageService, createNewFileCommandService);
+    CreateJPARepositoryCommandService createJPARepositoryCommandService =
+        new CreateJPARepositoryCommandService(javaLanguageService);
     return new CommandFactory(
         renameCommandService,
         getMainClassCommandService,
         createNewFileCommandService,
         getCursorPositionInfoCommandService,
         parseSourceCodeCommandService,
-        createNewJPAEntityCommandService);
+        createNewJPAEntityCommandService,
+        createJPARepositoryCommandService);
   }
 }

--- a/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
@@ -49,6 +49,12 @@ public class CreateJPARepositoryCommand
       required = true)
   private SupportedIDE ide = SupportedIDE.NONE;
 
+  @Option(
+      names = "--superclass-source",
+      description = "Source code for missing superclass when external symbol is required",
+      required = false)
+  private String superclassSource;
+
   @Override
   public DataTransferObject<CreateJPARepositoryResponse> call() {
     if (this.language.equals(SupportedLanguage.JAVA)) {
@@ -59,7 +65,8 @@ public class CreateJPARepositoryCommand
           this.ide,
           this.entityType,
           this.entityIdType,
-          this.entityPackageName);
+          this.entityPackageName,
+          this.superclassSource);
     }
     return DataTransferObject.error("Language not supported.");
   }

--- a/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
@@ -1,47 +1,63 @@
-// package io.github.syntaxpresso.core.command;
-//
-// import io.github.syntaxpresso.core.command.dto.CreateNewFileResponse;
-// import io.github.syntaxpresso.core.common.DataTransferObject;
-// import io.github.syntaxpresso.core.common.extra.SupportedIDE;
-// import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
-// import io.github.syntaxpresso.core.service.java.JavaCommandService;
-// import java.nio.file.Path;
-// import java.util.concurrent.Callable;
-// import lombok.RequiredArgsConstructor;
-// import picocli.CommandLine.Command;
-// import picocli.CommandLine.Option;
-//
-// @RequiredArgsConstructor
-// @Command(
-//     name = "create-jpa-repository",
-//     description = "Create JPA Repository for the current JPA Entity.")
-// public class CreateJPARepositoryCommand
-//     implements Callable<DataTransferObject<CreateNewFileResponse>> {
-//   private final JavaCommandService javaService;
-//
-//   @Option(names = "--cwd", description = "Current Working Directory", required = true)
-//   private Path cwd;
-//
-//   @Option(names = "--file-path", description = "The path to the file", required = true)
-//   private Path filePath;
-//
-//   @Option(
-//       names = "--language",
-//       description = "The language related to the command execution.",
-//       required = true)
-//   private SupportedLanguage language;
-//
-//   @Option(
-//       names = "--ide",
-//       description = "The IDE the command is being called from.",
-//       required = true)
-//   private SupportedIDE ide = SupportedIDE.NONE;
-//
-//   @Override
-//   public DataTransferObject<CreateNewFileResponse> call() {
-//     if (this.language.equals(SupportedLanguage.JAVA)) {
-//       return this.javaService.createJPARepository(this.cwd, this.filePath);
-//     }
-//     return DataTransferObject.error("Language not supported.");
-//   }
-// }
+package io.github.syntaxpresso.core.command;
+
+import io.github.syntaxpresso.core.command.dto.CreateJPARepositoryResponse;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.command.CreateJPARepositoryCommandService;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import lombok.RequiredArgsConstructor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@RequiredArgsConstructor
+@Command(
+    name = "create-jpa-repository",
+    description = "Create JPA Repository for the current JPA Entity.")
+public class CreateJPARepositoryCommand
+    implements Callable<DataTransferObject<CreateJPARepositoryResponse>> {
+  private final CreateJPARepositoryCommandService createJPARepositoryCommandService;
+
+  @Option(names = "--cwd", description = "Current Working Directory", required = true)
+  private Path cwd;
+
+  @Option(names = "--file-path", description = "The path to the file", required = true)
+  private Path filePath;
+
+  @Option(names = "--entity-type", description = "The JPA Entity type", required = false)
+  private String entityType;
+
+  @Option(names = "--entity-id-type", description = "The JPA Entity's ID type", required = false)
+  private String entityIdType;
+
+  @Option(names = "--package-name", description = "The JPA Entity's package name", required = false)
+  private String entityPackageName;
+
+  @Option(
+      names = "--language",
+      description = "The language related to the command execution.",
+      required = true)
+  private SupportedLanguage language;
+
+  @Option(
+      names = "--ide",
+      description = "The IDE the command is being called from.",
+      required = true)
+  private SupportedIDE ide = SupportedIDE.NONE;
+
+  @Override
+  public DataTransferObject<CreateJPARepositoryResponse> call() {
+    if (this.language.equals(SupportedLanguage.JAVA)) {
+      return this.createJPARepositoryCommandService.run(
+          this.cwd,
+          this.filePath,
+          this.language,
+          this.ide,
+          this.entityType,
+          this.entityIdType,
+          this.entityPackageName);
+    }
+    return DataTransferObject.error("Language not supported.");
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
@@ -25,18 +25,6 @@ public class CreateJPARepositoryCommand
   @Option(names = "--file-path", description = "The path to the file", required = true)
   private Path filePath;
 
-  @Option(names = "--entity-type", description = "The JPA Entity type", required = false)
-  private String entityType;
-
-  @Option(names = "--entity-id-type", description = "The JPA Entity's ID type", required = false)
-  private String entityIdType;
-
-  @Option(
-      names = "--entity-package-name",
-      description = "The JPA Entity's package name",
-      required = false)
-  private String entityPackageName;
-
   @Option(
       names = "--language",
       description = "The language related to the command execution.",
@@ -59,14 +47,7 @@ public class CreateJPARepositoryCommand
   public DataTransferObject<CreateJPARepositoryResponse> call() {
     if (this.language.equals(SupportedLanguage.JAVA)) {
       return this.createJPARepositoryCommandService.run(
-          this.cwd,
-          this.filePath,
-          this.language,
-          this.ide,
-          this.entityType,
-          this.entityIdType,
-          this.entityPackageName,
-          this.superclassSource);
+          this.cwd, this.filePath, this.language, this.ide, this.superclassSource);
     }
     return DataTransferObject.error("Language not supported.");
   }

--- a/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommand.java
@@ -31,7 +31,10 @@ public class CreateJPARepositoryCommand
   @Option(names = "--entity-id-type", description = "The JPA Entity's ID type", required = false)
   private String entityIdType;
 
-  @Option(names = "--package-name", description = "The JPA Entity's package name", required = false)
+  @Option(
+      names = "--entity-package-name",
+      description = "The JPA Entity's package name",
+      required = false)
   private String entityPackageName;
 
   @Option(

--- a/src/main/java/io/github/syntaxpresso/core/command/dto/CreateJPARepositoryResponse.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/dto/CreateJPARepositoryResponse.java
@@ -1,0 +1,16 @@
+package io.github.syntaxpresso.core.command.dto;
+
+import io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData;
+import java.io.Serializable;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateJPARepositoryResponse implements Serializable {
+  private String filePath;
+  private Boolean requiresSymbolSource;
+  private String symbol;
+  private JPARepositoryData repositoryData;
+}

--- a/src/main/java/io/github/syntaxpresso/core/command/dto/CreateJPARepositoryResponse.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/dto/CreateJPARepositoryResponse.java
@@ -1,5 +1,7 @@
 package io.github.syntaxpresso.core.command.dto;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData;
 import java.io.Serializable;
 import lombok.*;
@@ -8,9 +10,17 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY, setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY)
 public class CreateJPARepositoryResponse implements Serializable {
+  @JsonProperty("filePath")
   private String filePath;
+  
+  @JsonProperty("requiresSymbolSource")
   private Boolean requiresSymbolSource;
+  
+  @JsonProperty("symbol")
   private String symbol;
+  
+  @JsonProperty("repositoryData")
   private JPARepositoryData repositoryData;
 }

--- a/src/main/java/io/github/syntaxpresso/core/command/extra/JavaFileTemplate.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/extra/JavaFileTemplate.java
@@ -5,7 +5,8 @@ public enum JavaFileTemplate {
   INTERFACE("package %s;%n%npublic interface %s {\n\n}"),
   ENUM("package %s;%n%npublic enum %s {\n\n}"),
   RECORD("package %s;%n%npublic record %s(\n\n) {\n\n}"),
-  ANNOTATION("package %s;%n%npublic @interface %s {\n\n}");
+  ANNOTATION("package %s;%n%npublic @interface %s {\n\n}"),
+  JPA_REPOSITORY("package %s;%n%nimport org.springframework.data.jpa.repository.JpaRepository;%nimport org.springframework.stereotype.Repository;%n%n@Repository%npublic interface %sRepository extends JpaRepository<%s, %s> {%n%n}");
   private final String template;
 
   JavaFileTemplate(String template) {
@@ -13,6 +14,13 @@ public enum JavaFileTemplate {
   }
 
   public String getSourceContent(String packageName, String className) {
+    return String.format(this.template, packageName, className);
+  }
+
+  public String getSourceContent(String packageName, String className, String entityType, String idType) {
+    if (this == JPA_REPOSITORY) {
+      return String.format(this.template, packageName, entityType, entityType, idType);
+    }
     return String.format(this.template, packageName, className);
   }
 }

--- a/src/main/java/io/github/syntaxpresso/core/command/extra/JavaFileTemplate.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/extra/JavaFileTemplate.java
@@ -5,8 +5,7 @@ public enum JavaFileTemplate {
   INTERFACE("package %s;%n%npublic interface %s {\n\n}"),
   ENUM("package %s;%n%npublic enum %s {\n\n}"),
   RECORD("package %s;%n%npublic record %s(\n\n) {\n\n}"),
-  ANNOTATION("package %s;%n%npublic @interface %s {\n\n}"),
-  JPA_REPOSITORY("package %s;%n%nimport org.springframework.data.jpa.repository.JpaRepository;%nimport org.springframework.stereotype.Repository;%n%n@Repository%npublic interface %sRepository extends JpaRepository<%s, %s> {%n%n}");
+  ANNOTATION("package %s;%n%npublic @interface %s {\n\n}");
   private final String template;
 
   JavaFileTemplate(String template) {
@@ -17,10 +16,8 @@ public enum JavaFileTemplate {
     return String.format(this.template, packageName, className);
   }
 
-  public String getSourceContent(String packageName, String className, String entityType, String idType) {
-    if (this == JPA_REPOSITORY) {
-      return String.format(this.template, packageName, entityType, entityType, idType);
-    }
+  public String getSourceContent(
+      String packageName, String className, String entityType, String idType) {
     return String.format(this.template, packageName, className);
   }
 }

--- a/src/main/java/io/github/syntaxpresso/core/common/CommandFactory.java
+++ b/src/main/java/io/github/syntaxpresso/core/common/CommandFactory.java
@@ -13,6 +13,7 @@ public class CommandFactory implements IFactory {
   private final GetCursorPositionInfoCommandService getCursorPositionInfoCommandService;
   private final ParseSourceCodeCommandService parseSourceCodeCommandService;
   private final CreateNewJPAEntityCommandService createNewJPAEntityCommandService;
+  private final CreateJPARepositoryCommandService createJPARepositoryCommandService;
 
   @Override
   @SuppressWarnings("unchecked")
@@ -35,9 +36,9 @@ public class CommandFactory implements IFactory {
     if (cls == CreateNewJPAEntityCommand.class) {
       return (K) new CreateNewJPAEntityCommand(createNewJPAEntityCommandService);
     }
-    // if (cls == CreateJPARepositoryCommand.class) {
-    //   return (K) new CreateJPARepositoryCommand(javaCommandService);
-    // }
+    if (cls == CreateJPARepositoryCommand.class) {
+      return (K) new CreateJPARepositoryCommand(createJPARepositoryCommandService);
+    }
     // if (cls == GetJPAEntityInfoCommand.class) {
     //   return (K) new GetJPAEntityInfoCommand(javaCommandService);
     // }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/JavaLanguageService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/JavaLanguageService.java
@@ -7,6 +7,7 @@ import io.github.syntaxpresso.core.service.extra.JavaIdentifierType;
 import io.github.syntaxpresso.core.service.java.language.AnnotationService;
 import io.github.syntaxpresso.core.service.java.language.ClassDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.ImportDeclarationService;
+import io.github.syntaxpresso.core.service.java.language.InterfaceDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.LocalVariableDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.PackageDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.VariableNamingService;
@@ -24,6 +25,7 @@ public class JavaLanguageService {
   private final PathHelper pathHelper;
   private final VariableNamingService variableNamingService;
   private final ClassDeclarationService classDeclarationService;
+  private final InterfaceDeclarationService interfaceDeclarationService;
   private final PackageDeclarationService packageDeclarationService;
   private final ImportDeclarationService importDeclarationService;
   private final LocalVariableDeclarationService localVariableDeclarationService;

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -1,8 +1,12 @@
 package io.github.syntaxpresso.core.service.java.command;
 
+import static io.github.syntaxpresso.core.service.java.language.extra.AnnotationInsertionPoint.AnnotationInsertionPosition.ABOVE_SCOPE_DECLARATION;
+
 import com.google.common.base.Strings;
 import io.github.syntaxpresso.core.command.dto.CreateJPARepositoryResponse;
 import io.github.syntaxpresso.core.command.dto.CreateNewFileResponse;
+import io.github.syntaxpresso.core.command.extra.JavaBasicType;
+import io.github.syntaxpresso.core.command.extra.JavaFileTemplate;
 import io.github.syntaxpresso.core.command.extra.JavaSourceDirectoryType;
 import io.github.syntaxpresso.core.common.DataTransferObject;
 import io.github.syntaxpresso.core.common.TSFile;
@@ -12,9 +16,10 @@ import io.github.syntaxpresso.core.service.java.JavaLanguageService;
 import io.github.syntaxpresso.core.service.java.command.extra.IdFieldSearchResult;
 import io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData;
 import io.github.syntaxpresso.core.service.java.command.extra.PrepareDataResult;
+import io.github.syntaxpresso.core.service.java.language.extra.AnnotationInsertionPoint;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +29,7 @@ import org.treesitter.TSNode;
 @RequiredArgsConstructor
 public class CreateJPARepositoryCommandService {
   private final JavaLanguageService javaLanguageService;
+  private final CreateNewFileCommandService createNewFileCommandService;
 
   private JPARepositoryData buildJPARepositoryData(
       Path cwd, String entityType, String entityIdType, String entityPackageName) {
@@ -100,12 +106,14 @@ public class CreateJPARepositoryCommandService {
     if (Strings.isNullOrEmpty(superClassName)) {
       return IdFieldSearchResult.notFound();
     }
-
     // First check if we have an external superclass file for this superclass
     if (externalSuperclassFile != null) {
       // For external source, we can't use getPublicClass() as it requires a filename
       // Instead, find any class declaration in the external source
-      Optional<TSNode> externalClassNode = this.findFirstClassDeclaration(externalSuperclassFile);
+      Optional<TSNode> externalClassNode =
+          this.javaLanguageService
+              .getClassDeclarationService()
+              .getPublicClass(externalSuperclassFile);
       if (externalClassNode.isPresent()) {
         Optional<String> externalClassName =
             this.extractEntityType(externalSuperclassFile, externalClassNode.get());
@@ -119,7 +127,6 @@ public class CreateJPARepositoryCommandService {
       // don't ask for the same superclass again - treat as not found
       return IdFieldSearchResult.notFound();
     }
-
     Optional<TSFile> superClassFile = this.findSuperclassFile(cwd, tsFile, publicClassNode);
     if (superClassFile.isEmpty()) {
       return IdFieldSearchResult.missingSuperclass(superClassName);
@@ -133,31 +140,14 @@ public class CreateJPARepositoryCommandService {
         cwd, superClassFile.get(), superClassPublicNode.get(), externalSuperclassFile);
   }
 
-  /**
-   * Finds the first class declaration in a TSFile, regardless of its name or visibility. This is
-   * useful for external source code where we don't have a filename to match against.
-   */
-  private Optional<TSNode> findFirstClassDeclaration(TSFile tsFile) {
-    if (tsFile == null || tsFile.getTree() == null) {
-      return Optional.empty();
-    }
-    return tsFile
-        .query("(class_declaration) @class")
-        .returning("class")
-        .execute()
-        .firstNodeOptional();
-  }
-
   private Optional<String> extractEntityType(TSFile tsFile, TSNode publicClassNode) {
     Optional<TSNode> classNameNode =
         this.javaLanguageService
             .getClassDeclarationService()
             .getClassDeclarationNameNode(tsFile, publicClassNode);
-
     if (classNameNode.isEmpty()) {
       return Optional.empty();
     }
-
     String className = tsFile.getTextFromNode(classNameNode.get());
     return Strings.isNullOrEmpty(className) ? Optional.empty() : Optional.of(className);
   }
@@ -168,11 +158,9 @@ public class CreateJPARepositoryCommandService {
             .getClassDeclarationService()
             .getFieldDeclarationService()
             .getFieldDeclarationFullTypeNode(tsFile, idFieldNode);
-
     if (fieldTypeNode.isEmpty()) {
       return Optional.empty();
     }
-
     String idType = tsFile.getTextFromNode(fieldTypeNode.get());
     return Strings.isNullOrEmpty(idType) ? Optional.empty() : Optional.of(idType);
   }
@@ -202,41 +190,86 @@ public class CreateJPARepositoryCommandService {
       return DataTransferObject.error("Entity type, ID type, and package name are required.");
     }
     String repositoryName = jpaRepositoryData.getEntityType() + "Repository";
-    String template =
-        String.format(
-            "package %s;\n\nimport org.springframework.data.jpa.repository.JpaRepository;\nimport"
-                + " org.springframework.stereotype.Repository;\n\n@Repository\npublic interface"
-                + " %s extends JpaRepository<%s, %s> {}",
+    DataTransferObject<CreateNewFileResponse> createNewFileResponse =
+        this.createNewFileCommandService.run(
+            jpaRepositoryData.getCwd(),
             jpaRepositoryData.getPackageName(),
             repositoryName,
-            jpaRepositoryData.getEntityType(),
-            jpaRepositoryData.getEntityIdType());
+            JavaFileTemplate.INTERFACE,
+            JavaSourceDirectoryType.MAIN);
+    if (!createNewFileResponse.getSucceed()) {
+      return DataTransferObject.error("Unable to create file.");
+    }
+    TSFile tsFile =
+        new TSFile(
+            SupportedLanguage.JAVA, Paths.get(createNewFileResponse.getData().getFilePath()));
+    Optional<TSNode> packageDeclarationNode =
+        this.javaLanguageService.getPackageDeclarationService().getPackageDeclarationNode(tsFile);
+    if (packageDeclarationNode.isEmpty()) {
+      return DataTransferObject.error(
+          "Unable to get the package declaration node of the newly created file.");
+    }
+    this.javaLanguageService
+        .getImportDeclarationService()
+        .addImport(
+            tsFile,
+            "org.springframework.data.jpa.repository",
+            "JpaRepository",
+            packageDeclarationNode.get());
+    this.javaLanguageService
+        .getImportDeclarationService()
+        .addImport(
+            tsFile, "org.springframework.stereotype", "Repository", packageDeclarationNode.get());
+    Optional<JavaBasicType> typeToImport =
+        JavaBasicType.getByTypeName(jpaRepositoryData.getEntityIdType());
+    if (typeToImport.isPresent()) {
+      if (typeToImport.get().getPackageName().isPresent()) {
+        this.javaLanguageService
+            .getImportDeclarationService()
+            .addImport(
+                tsFile,
+                typeToImport.get().getPackageName().get(),
+                typeToImport.get().getTypeName(),
+                packageDeclarationNode.get());
+      }
+    }
+    Optional<TSNode> publicInterfaceNode =
+        this.javaLanguageService.getInterfaceDeclarationService().getPublicInterface(tsFile);
+    if (publicInterfaceNode.isEmpty()) {
+      return DataTransferObject.error("Unable to get the public interface node of the repository.");
+    }
+    Optional<TSNode> publicInterfaceNameNode =
+        this.javaLanguageService
+            .getInterfaceDeclarationService()
+            .getInterfaceNameNode(tsFile, publicInterfaceNode.get());
+    if (publicInterfaceNameNode.isEmpty()) {
+      return DataTransferObject.error(
+          "Unable to get the public interface name node of the repository.");
+    }
+    String template =
+        String.format(
+            " extends JpaRepository<%s, %s> ",
+            jpaRepositoryData.getEntityType(), jpaRepositoryData.getEntityIdType());
+    tsFile.updateSourceCode(
+        publicInterfaceNameNode.get().getEndByte(),
+        publicInterfaceNameNode.get().getEndByte(),
+        template);
+    AnnotationInsertionPoint repositoryAnnotationPoint =
+        this.javaLanguageService
+            .getAnnotationService()
+            .getAnnotationInsertionPosition(
+                tsFile, publicInterfaceNode.get(), ABOVE_SCOPE_DECLARATION);
+    this.javaLanguageService
+        .getAnnotationService()
+        .addAnnotation(tsFile, publicInterfaceNode.get(), repositoryAnnotationPoint, "@Repository");
     try {
-      TSFile file = new TSFile(SupportedLanguage.JAVA, template);
-      Optional<Path> filePath =
-          this.javaLanguageService
-              .getPackageDeclarationService()
-              .getFilePathFromPackageScope(
-                  jpaRepositoryData.getCwd(),
-                  jpaRepositoryData.getPackageName(),
-                  JavaSourceDirectoryType.MAIN);
-      if (filePath.isEmpty()) {
-        return DataTransferObject.error("Package directory could not be determined.");
-      }
-      Path targetPath =
-          filePath.get().resolve(repositoryName + SupportedLanguage.JAVA.getFileExtension());
-      if (Files.exists(targetPath)) {
-        return DataTransferObject.error("Repository file already exists: " + targetPath.toString());
-      }
-      file.saveAs(targetPath);
-      CreateNewFileResponse response =
-          CreateNewFileResponse.builder().filePath(file.getFile().getAbsolutePath()).build();
-      return DataTransferObject.success(response);
+      tsFile.save();
     } catch (IOException e) {
       return DataTransferObject.error("Failed to create repository file: " + e.getMessage());
-    } catch (Exception e) {
-      return DataTransferObject.error("Unexpected error occurred: " + e.getMessage());
     }
+    CreateNewFileResponse response =
+        CreateNewFileResponse.builder().filePath(tsFile.getFile().getAbsolutePath()).build();
+    return DataTransferObject.success(response);
   }
 
   public PrepareDataResult prepareData(TSFile tsFile, Path cwd) {

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -252,7 +252,9 @@ public class CreateJPARepositoryCommandService {
     }
     TSFile externalSuperclassFile = null;
     if (!Strings.isNullOrEmpty(superclassSource)) {
-      externalSuperclassFile = new TSFile(SupportedLanguage.JAVA, superclassSource);
+      // Convert escaped newlines to actual newlines for proper parsing
+      String processedSource = superclassSource.replace("\\n", "\n").replace("\\\"", "\"");
+      externalSuperclassFile = new TSFile(SupportedLanguage.JAVA, processedSource);
     }
     IdFieldSearchResult searchResult =
         this.findIdFieldRecursively(cwd, tsFile, publicClassNode.get(), externalSuperclassFile);

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -15,6 +15,7 @@ import io.github.syntaxpresso.core.service.java.command.extra.PrepareDataResult;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -243,27 +244,36 @@ public class CreateJPARepositoryCommandService {
   }
 
   public PrepareDataResult prepareData(TSFile tsFile, Path cwd, String superclassSource) {
-    Optional<TSNode> publicClassNode =
+    Optional<TSNode> entityPublicClassNode =
         this.javaLanguageService.getClassDeclarationService().getPublicClass(tsFile);
-    if (publicClassNode.isEmpty()) {
+    if (entityPublicClassNode.isEmpty()) {
       return PrepareDataResult.error("No public class found in the entity file.");
     }
     Optional<String> packageName = this.extractPackageName(tsFile);
     if (packageName.isEmpty()) {
       return PrepareDataResult.error("Package name could not be extracted from the entity file.");
     }
-    Optional<String> entityType = this.extractEntityType(tsFile, publicClassNode.get());
+    Optional<String> entityType = this.extractEntityType(tsFile, entityPublicClassNode.get());
     if (entityType.isEmpty()) {
       return PrepareDataResult.error("Entity type could not be extracted from the entity file.");
     }
+    IdFieldSearchResult searchResult;
     TSFile externalSuperclassFile = null;
     if (!Strings.isNullOrEmpty(superclassSource)) {
-      // Convert escaped newlines to actual newlines for proper parsing
-      String processedSource = superclassSource.replace("\\n", "\n").replace("\\\"", "\"");
-      externalSuperclassFile = new TSFile(SupportedLanguage.JAVA, processedSource);
+      externalSuperclassFile = new TSFile(SupportedLanguage.JAVA, superclassSource);
+      Optional<TSNode> externalSuperclassFilePublicClassNode =
+          this.javaLanguageService
+              .getClassDeclarationService()
+              .getPublicClass(externalSuperclassFile);
+      if (externalSuperclassFilePublicClassNode.isEmpty()) {
+        return PrepareDataResult.error("No public class found in the entity file.");
+      }
+      searchResult =
+          this.findIdFieldRecursively(
+              cwd, externalSuperclassFile, externalSuperclassFilePublicClassNode.get());
+    } else {
+      searchResult = this.findIdFieldRecursively(cwd, tsFile, entityPublicClassNode.get());
     }
-    IdFieldSearchResult searchResult =
-        this.findIdFieldRecursively(cwd, tsFile, publicClassNode.get(), externalSuperclassFile);
     if (searchResult.isFound()) {
       // Id field found - extract ID type and create JPARepositoryData
       Optional<String> idType =
@@ -301,8 +311,17 @@ public class CreateJPARepositoryCommandService {
       SupportedLanguage language,
       SupportedIDE ide,
       String superclassSource) {
+    String decodedSuperclassSource = null;
+    if (!Strings.isNullOrEmpty(superclassSource)) {
+      try {
+        decodedSuperclassSource = new String(Base64.getDecoder().decode(superclassSource));
+      } catch (IllegalArgumentException e) {
+        return DataTransferObject.error(
+            "Invalid base64 encoding in superclass source: " + e.getMessage());
+      }
+    }
     TSFile tsFile = new TSFile(language, filePath);
-    PrepareDataResult prepareResult = this.prepareData(tsFile, cwd, superclassSource);
+    PrepareDataResult prepareResult = this.prepareData(tsFile, cwd, decodedSuperclassSource);
     if (prepareResult.requiresSymbolSource()) {
       return DataTransferObject.success(prepareResult.getRequiresSymbolResponse());
     }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -106,13 +106,15 @@ public class CreateJPARepositoryCommandService {
       // Instead, find any class declaration in the external source
       Optional<TSNode> externalClassNode = this.findFirstClassDeclaration(externalSuperclassFile);
       if (externalClassNode.isPresent()) {
-        Optional<String> externalClassName = this.extractEntityType(externalSuperclassFile, externalClassNode.get());
+        Optional<String> externalClassName =
+            this.extractEntityType(externalSuperclassFile, externalClassNode.get());
         if (externalClassName.isPresent() && externalClassName.get().equals(superClassName)) {
           // We found the matching external superclass, search within it
-          return this.findIdFieldRecursively(cwd, externalSuperclassFile, externalClassNode.get(), null);
+          return this.findIdFieldRecursively(
+              cwd, externalSuperclassFile, externalClassNode.get(), null);
         }
       }
-      // If we have external source but it doesn't match the expected class name, 
+      // If we have external source but it doesn't match the expected class name,
       // don't ask for the same superclass again - treat as not found
       return IdFieldSearchResult.notFound();
     }
@@ -131,14 +133,18 @@ public class CreateJPARepositoryCommandService {
   }
 
   /**
-   * Finds the first class declaration in a TSFile, regardless of its name or visibility.
-   * This is useful for external source code where we don't have a filename to match against.
+   * Finds the first class declaration in a TSFile, regardless of its name or visibility. This is
+   * useful for external source code where we don't have a filename to match against.
    */
   private Optional<TSNode> findFirstClassDeclaration(TSFile tsFile) {
     if (tsFile == null || tsFile.getTree() == null) {
       return Optional.empty();
     }
-    return tsFile.query("(class_declaration) @class").returning("class").execute().firstNodeOptional();
+    return tsFile
+        .query("(class_declaration) @class")
+        .returning("class")
+        .execute()
+        .firstNodeOptional();
   }
 
   private Optional<String> extractEntityType(TSFile tsFile, TSNode publicClassNode) {
@@ -294,30 +300,16 @@ public class CreateJPARepositoryCommandService {
       Path filePath,
       SupportedLanguage language,
       SupportedIDE ide,
-      String entityType,
-      String entityIdType,
-      String entityPackageName,
       String superclassSource) {
     TSFile tsFile = new TSFile(language, filePath);
-    JPARepositoryData jpaRepositoryData;
-    if (Strings.isNullOrEmpty(entityIdType)
-        && Strings.isNullOrEmpty(entityType)
-        && Strings.isNullOrEmpty(entityPackageName)) {
-      PrepareDataResult prepareResult = this.prepareData(tsFile, cwd, superclassSource);
-      if (prepareResult.requiresSymbolSource()) {
-        return DataTransferObject.success(prepareResult.getRequiresSymbolResponse());
-      }
-      if (prepareResult.isError()) {
-        return DataTransferObject.error(prepareResult.getErrorMessage());
-      }
-      jpaRepositoryData = prepareResult.getRepositoryData();
-    } else {
-      jpaRepositoryData =
-          this.buildJPARepositoryData(cwd, entityType, entityIdType, entityPackageName);
-      if (jpaRepositoryData == null) {
-        return DataTransferObject.error("Unable to gather necessary repository data.");
-      }
+    PrepareDataResult prepareResult = this.prepareData(tsFile, cwd, superclassSource);
+    if (prepareResult.requiresSymbolSource()) {
+      return DataTransferObject.success(prepareResult.getRequiresSymbolResponse());
     }
+    if (prepareResult.isError()) {
+      return DataTransferObject.error(prepareResult.getErrorMessage());
+    }
+    JPARepositoryData jpaRepositoryData = prepareResult.getRepositoryData();
     DataTransferObject<CreateNewFileResponse> createFileResult =
         this.createRepositoryFile(jpaRepositoryData);
     if (!createFileResult.getSucceed()) {

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -11,6 +11,7 @@ import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.java.JavaLanguageService;
 import io.github.syntaxpresso.core.service.java.command.extra.IdFieldSearchResult;
 import io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData;
+import io.github.syntaxpresso.core.service.java.command.extra.PrepareDataResult;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -78,6 +79,11 @@ public class CreateJPARepositoryCommandService {
 
   private IdFieldSearchResult findIdFieldRecursively(
       Path cwd, TSFile tsFile, TSNode publicClassNode) {
+    return this.findIdFieldRecursively(cwd, tsFile, publicClassNode, null);
+  }
+
+  private IdFieldSearchResult findIdFieldRecursively(
+      Path cwd, TSFile tsFile, TSNode publicClassNode, TSFile externalSuperclassFile) {
     Optional<TSNode> idFieldNode = this.getIdFieldFromEntity(tsFile, publicClassNode);
     if (idFieldNode.isPresent()) {
       return IdFieldSearchResult.found(tsFile, idFieldNode.get());
@@ -93,6 +99,24 @@ public class CreateJPARepositoryCommandService {
     if (Strings.isNullOrEmpty(superClassName)) {
       return IdFieldSearchResult.notFound();
     }
+
+    // First check if we have an external superclass file for this superclass
+    if (externalSuperclassFile != null) {
+      // For external source, we can't use getPublicClass() as it requires a filename
+      // Instead, find any class declaration in the external source
+      Optional<TSNode> externalClassNode = this.findFirstClassDeclaration(externalSuperclassFile);
+      if (externalClassNode.isPresent()) {
+        Optional<String> externalClassName = this.extractEntityType(externalSuperclassFile, externalClassNode.get());
+        if (externalClassName.isPresent() && externalClassName.get().equals(superClassName)) {
+          // We found the matching external superclass, search within it
+          return this.findIdFieldRecursively(cwd, externalSuperclassFile, externalClassNode.get(), null);
+        }
+      }
+      // If we have external source but it doesn't match the expected class name, 
+      // don't ask for the same superclass again - treat as not found
+      return IdFieldSearchResult.notFound();
+    }
+
     Optional<TSFile> superClassFile = this.findSuperclassFile(cwd, tsFile, publicClassNode);
     if (superClassFile.isEmpty()) {
       return IdFieldSearchResult.missingSuperclass(superClassName);
@@ -102,7 +126,19 @@ public class CreateJPARepositoryCommandService {
     if (superClassPublicNode.isEmpty()) {
       return IdFieldSearchResult.notFound();
     }
-    return this.findIdFieldRecursively(cwd, superClassFile.get(), superClassPublicNode.get());
+    return this.findIdFieldRecursively(
+        cwd, superClassFile.get(), superClassPublicNode.get(), externalSuperclassFile);
+  }
+
+  /**
+   * Finds the first class declaration in a TSFile, regardless of its name or visibility.
+   * This is useful for external source code where we don't have a filename to match against.
+   */
+  private Optional<TSNode> findFirstClassDeclaration(TSFile tsFile) {
+    if (tsFile == null || tsFile.getTree() == null) {
+      return Optional.empty();
+    }
+    return tsFile.query("(class_declaration) @class").returning("class").execute().firstNodeOptional();
   }
 
   private Optional<String> extractEntityType(TSFile tsFile, TSNode publicClassNode) {
@@ -196,33 +232,40 @@ public class CreateJPARepositoryCommandService {
     }
   }
 
-  public JPARepositoryData prepareData(TSFile tsFile, Path cwd) {
+  public PrepareDataResult prepareData(TSFile tsFile, Path cwd) {
+    return this.prepareData(tsFile, cwd, null);
+  }
+
+  public PrepareDataResult prepareData(TSFile tsFile, Path cwd, String superclassSource) {
     Optional<TSNode> publicClassNode =
         this.javaLanguageService.getClassDeclarationService().getPublicClass(tsFile);
     if (publicClassNode.isEmpty()) {
-      return null;
+      return PrepareDataResult.error("No public class found in the entity file.");
     }
     Optional<String> packageName = this.extractPackageName(tsFile);
     if (packageName.isEmpty()) {
-      return null;
+      return PrepareDataResult.error("Package name could not be extracted from the entity file.");
     }
     Optional<String> entityType = this.extractEntityType(tsFile, publicClassNode.get());
     if (entityType.isEmpty()) {
-      return null;
+      return PrepareDataResult.error("Entity type could not be extracted from the entity file.");
+    }
+    TSFile externalSuperclassFile = null;
+    if (!Strings.isNullOrEmpty(superclassSource)) {
+      externalSuperclassFile = new TSFile(SupportedLanguage.JAVA, superclassSource);
     }
     IdFieldSearchResult searchResult =
-        this.findIdFieldRecursively(cwd, tsFile, publicClassNode.get());
+        this.findIdFieldRecursively(cwd, tsFile, publicClassNode.get(), externalSuperclassFile);
     if (searchResult.isFound()) {
       // Id field found - extract ID type and create JPARepositoryData
       Optional<String> idType =
           this.extractIdType(searchResult.getTsFile(), searchResult.getIdFieldNode());
       if (idType.isEmpty()) {
-        return null;
+        return PrepareDataResult.error("ID field type could not be extracted.");
       }
-
       JPARepositoryData repositoryData =
           this.buildJPARepositoryData(cwd, entityType.get(), idType.get(), packageName.get());
-      return repositoryData;
+      return PrepareDataResult.success(repositoryData);
     } else if (searchResult.hasMissingSuperclass()) {
       // Superclass exists but file not found - return response requiring symbol source
       CreateJPARepositoryResponse response =
@@ -231,10 +274,11 @@ public class CreateJPARepositoryCommandService {
               .symbol(searchResult.getMissingSuperclassName())
               .requiresSymbolSource(true)
               .build();
-      return null;
+      return PrepareDataResult.requiresSymbolSource(response);
     } else {
       // No Id field found in entire hierarchy
-      return null;
+      return PrepareDataResult.error(
+          "No @Id field found in the entity or its superclass hierarchy.");
     }
   }
 
@@ -250,16 +294,21 @@ public class CreateJPARepositoryCommandService {
       SupportedIDE ide,
       String entityType,
       String entityIdType,
-      String entityPackageName) {
+      String entityPackageName,
+      String superclassSource) {
     TSFile tsFile = new TSFile(language, filePath);
-    JPARepositoryData jpaRepositoryData = new JPARepositoryData();
+    JPARepositoryData jpaRepositoryData;
     if (Strings.isNullOrEmpty(entityIdType)
         && Strings.isNullOrEmpty(entityType)
         && Strings.isNullOrEmpty(entityPackageName)) {
-      jpaRepositoryData = this.prepareData(tsFile, cwd);
-      if (jpaRepositoryData == null) {
-        return DataTransferObject.error("Could not extract repository data from entity file.");
+      PrepareDataResult prepareResult = this.prepareData(tsFile, cwd, superclassSource);
+      if (prepareResult.requiresSymbolSource()) {
+        return DataTransferObject.success(prepareResult.getRequiresSymbolResponse());
       }
+      if (prepareResult.isError()) {
+        return DataTransferObject.error(prepareResult.getErrorMessage());
+      }
+      jpaRepositoryData = prepareResult.getRepositoryData();
     } else {
       jpaRepositoryData =
           this.buildJPARepositoryData(cwd, entityType, entityIdType, entityPackageName);

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -137,20 +137,16 @@ public class CreateJPARepositoryCommandService {
   private Optional<String> extractPackageName(TSFile tsFile) {
     Optional<TSNode> packageDeclarationNode =
         this.javaLanguageService.getPackageDeclarationService().getPackageDeclarationNode(tsFile);
-
     if (packageDeclarationNode.isEmpty()) {
       return Optional.empty();
     }
-
     Optional<TSNode> packageScopeNode =
         this.javaLanguageService
             .getPackageDeclarationService()
             .getPackageScopeNode(tsFile, packageDeclarationNode.get());
-
     if (packageScopeNode.isEmpty()) {
       return Optional.empty();
     }
-
     String packageName = tsFile.getTextFromNode(packageScopeNode.get());
     return Strings.isNullOrEmpty(packageName) ? Optional.empty() : Optional.of(packageName);
   }
@@ -218,7 +214,8 @@ public class CreateJPARepositoryCommandService {
         this.findIdFieldRecursively(cwd, tsFile, publicClassNode.get());
     if (searchResult.isFound()) {
       // Id field found - extract ID type and create JPARepositoryData
-      Optional<String> idType = this.extractIdType(tsFile, searchResult.getIdFieldNode());
+      Optional<String> idType =
+          this.extractIdType(searchResult.getTsFile(), searchResult.getIdFieldNode());
       if (idType.isEmpty()) {
         return null;
       }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -1,0 +1,285 @@
+package io.github.syntaxpresso.core.service.java.command;
+
+import com.google.common.base.Strings;
+import io.github.syntaxpresso.core.command.dto.CreateJPARepositoryResponse;
+import io.github.syntaxpresso.core.command.dto.CreateNewFileResponse;
+import io.github.syntaxpresso.core.command.extra.JavaSourceDirectoryType;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.TSFile;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.JavaLanguageService;
+import io.github.syntaxpresso.core.service.java.command.extra.IdFieldSearchResult;
+import io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.treesitter.TSNode;
+
+@RequiredArgsConstructor
+public class CreateJPARepositoryCommandService {
+  private final JavaLanguageService javaLanguageService;
+
+  private JPARepositoryData buildJPARepositoryData(
+      Path cwd, String entityType, String entityIdType, String entityPackageName) {
+    return JPARepositoryData.builder()
+        .cwd(cwd)
+        .packageName(entityPackageName)
+        .entityType(entityType)
+        .entityIdType(entityIdType)
+        .build();
+  }
+
+  private Optional<TSNode> getIdFieldFromEntity(TSFile tsFile, TSNode publicClassNode) {
+    List<TSNode> publicClassFieldNodes =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getFieldDeclarationService()
+            .getAllFieldDeclarationNodes(tsFile, publicClassNode);
+    for (TSNode classFieldNode : publicClassFieldNodes) {
+      Optional<TSNode> idFieldAnnotation =
+          this.javaLanguageService
+              .getAnnotationService()
+              .findAnnotationByName(tsFile, classFieldNode, "Id");
+      if (idFieldAnnotation.isPresent()) {
+        return Optional.of(classFieldNode);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private Optional<TSFile> findSuperclassFile(Path cwd, TSFile entityFile, TSNode publicClassNode) {
+    Optional<TSNode> superClassNameNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getClassDeclarationSuperclassNameNode(entityFile, publicClassNode);
+    if (superClassNameNode.isEmpty()) {
+      return Optional.empty();
+    }
+    String superClassName = entityFile.getTextFromNode(superClassNameNode.get());
+    if (Strings.isNullOrEmpty(superClassName)) {
+      return Optional.empty();
+    }
+    List<TSFile> allJavaFiles = this.javaLanguageService.getAllJavaFilesFromCwd(cwd);
+    for (TSFile tsFile : allJavaFiles) {
+      Optional<String> fileName = tsFile.getFileNameWithoutExtension();
+      if (fileName.isEmpty()) {
+        continue;
+      }
+      if (fileName.get().equals(superClassName)) {
+        return Optional.of(tsFile);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private IdFieldSearchResult findIdFieldRecursively(
+      Path cwd, TSFile tsFile, TSNode publicClassNode) {
+    Optional<TSNode> idFieldNode = this.getIdFieldFromEntity(tsFile, publicClassNode);
+    if (idFieldNode.isPresent()) {
+      return IdFieldSearchResult.found(idFieldNode.get());
+    }
+    Optional<TSNode> superClassNameNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getClassDeclarationSuperclassNameNode(tsFile, publicClassNode);
+    if (superClassNameNode.isEmpty()) {
+      return IdFieldSearchResult.notFound();
+    }
+    String superClassName = tsFile.getTextFromNode(superClassNameNode.get());
+    if (Strings.isNullOrEmpty(superClassName)) {
+      return IdFieldSearchResult.notFound();
+    }
+    Optional<TSFile> superClassFile = this.findSuperclassFile(cwd, tsFile, publicClassNode);
+    if (superClassFile.isEmpty()) {
+      return IdFieldSearchResult.missingSuperclass(superClassName);
+    }
+    Optional<TSNode> superClassPublicNode =
+        this.javaLanguageService.getClassDeclarationService().getPublicClass(superClassFile.get());
+    if (superClassPublicNode.isEmpty()) {
+      return IdFieldSearchResult.notFound();
+    }
+    return this.findIdFieldRecursively(cwd, superClassFile.get(), superClassPublicNode.get());
+  }
+
+  private Optional<String> extractEntityType(TSFile tsFile, TSNode publicClassNode) {
+    Optional<TSNode> classNameNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getClassDeclarationNameNode(tsFile, publicClassNode);
+
+    if (classNameNode.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String className = tsFile.getTextFromNode(classNameNode.get());
+    return Strings.isNullOrEmpty(className) ? Optional.empty() : Optional.of(className);
+  }
+
+  private Optional<String> extractIdType(TSFile tsFile, TSNode idFieldNode) {
+    Optional<TSNode> fieldTypeNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getFieldDeclarationService()
+            .getFieldDeclarationFullTypeNode(tsFile, idFieldNode);
+
+    if (fieldTypeNode.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String idType = tsFile.getTextFromNode(fieldTypeNode.get());
+    return Strings.isNullOrEmpty(idType) ? Optional.empty() : Optional.of(idType);
+  }
+
+  private Optional<String> extractPackageName(TSFile tsFile) {
+    Optional<TSNode> packageDeclarationNode =
+        this.javaLanguageService.getPackageDeclarationService().getPackageDeclarationNode(tsFile);
+
+    if (packageDeclarationNode.isEmpty()) {
+      return Optional.empty();
+    }
+
+    Optional<TSNode> packageScopeNode =
+        this.javaLanguageService
+            .getPackageDeclarationService()
+            .getPackageScopeNode(tsFile, packageDeclarationNode.get());
+
+    if (packageScopeNode.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String packageName = tsFile.getTextFromNode(packageScopeNode.get());
+    return Strings.isNullOrEmpty(packageName) ? Optional.empty() : Optional.of(packageName);
+  }
+
+  private DataTransferObject<CreateNewFileResponse> createRepositoryFile(
+      JPARepositoryData jpaRepositoryData) {
+    if (Strings.isNullOrEmpty(jpaRepositoryData.getPackageName())
+        || Strings.isNullOrEmpty(jpaRepositoryData.getEntityType())
+        || Strings.isNullOrEmpty(jpaRepositoryData.getEntityIdType())) {
+      return DataTransferObject.error("Entity type, ID type, and package name are required.");
+    }
+    String repositoryName = jpaRepositoryData.getEntityType() + "Repository";
+    String template =
+        String.format(
+            "package %s;\n\nimport org.springframework.data.jpa.repository.JpaRepository;\nimport"
+                + " org.springframework.stereotype.Repository;\n\n@Repository\npublic interface"
+                + " %sRepository extends JpaRepository<%s, %s> {}",
+            jpaRepositoryData.getPackageName(),
+            repositoryName,
+            jpaRepositoryData.getEntityType(),
+            jpaRepositoryData.getEntityIdType());
+    try {
+      TSFile file = new TSFile(SupportedLanguage.JAVA, template);
+      Optional<Path> filePath =
+          this.javaLanguageService
+              .getPackageDeclarationService()
+              .getFilePathFromPackageScope(
+                  jpaRepositoryData.getCwd(),
+                  jpaRepositoryData.getPackageName(),
+                  JavaSourceDirectoryType.MAIN);
+      if (filePath.isEmpty()) {
+        return DataTransferObject.error("Package directory could not be determined.");
+      }
+      Path targetPath =
+          filePath.get().resolve(repositoryName + SupportedLanguage.JAVA.getFileExtension());
+      if (Files.exists(targetPath)) {
+        return DataTransferObject.error("Repository file already exists: " + targetPath.toString());
+      }
+      file.saveAs(targetPath);
+      CreateNewFileResponse response =
+          CreateNewFileResponse.builder().filePath(file.getFile().getAbsolutePath()).build();
+      return DataTransferObject.success(response);
+    } catch (IOException e) {
+      return DataTransferObject.error("Failed to create repository file: " + e.getMessage());
+    } catch (Exception e) {
+      return DataTransferObject.error("Unexpected error occurred: " + e.getMessage());
+    }
+  }
+
+  public JPARepositoryData prepareData(TSFile tsFile, Path cwd) {
+    Optional<TSNode> publicClassNode =
+        this.javaLanguageService.getClassDeclarationService().getPublicClass(tsFile);
+    if (publicClassNode.isEmpty()) {
+      return null;
+    }
+    Optional<String> packageName = this.extractPackageName(tsFile);
+    if (packageName.isEmpty()) {
+      return null;
+    }
+    Optional<String> entityType = this.extractEntityType(tsFile, publicClassNode.get());
+    if (entityType.isEmpty()) {
+      return null;
+    }
+    IdFieldSearchResult searchResult =
+        this.findIdFieldRecursively(cwd, tsFile, publicClassNode.get());
+    if (searchResult.isFound()) {
+      // Id field found - extract ID type and create JPARepositoryData
+      Optional<String> idType = this.extractIdType(tsFile, searchResult.getIdFieldNode());
+      if (idType.isEmpty()) {
+        return null;
+      }
+
+      JPARepositoryData repositoryData =
+          this.buildJPARepositoryData(cwd, entityType.get(), idType.get(), packageName.get());
+      return repositoryData;
+    } else if (searchResult.hasMissingSuperclass()) {
+      // Superclass exists but file not found - return response requiring symbol source
+      CreateJPARepositoryResponse response =
+          CreateJPARepositoryResponse.builder()
+              .filePath(tsFile.getFile().getAbsolutePath())
+              .symbol(searchResult.getMissingSuperclassName())
+              .requiresSymbolSource(true)
+              .build();
+      return null;
+    } else {
+      // No Id field found in entire hierarchy
+      return null;
+    }
+  }
+
+  public void getFileFromSource(Path cwd, String sourceCode) {
+    TSFile tsFile = new TSFile(SupportedLanguage.JAVA, sourceCode);
+    this.prepareData(tsFile, cwd);
+  }
+
+  public DataTransferObject<CreateJPARepositoryResponse> run(
+      Path cwd,
+      Path filePath,
+      SupportedLanguage language,
+      SupportedIDE ide,
+      String entityType,
+      String entityIdType,
+      String entityPackageName) {
+    TSFile tsFile = new TSFile(language, filePath);
+    JPARepositoryData jpaRepositoryData = new JPARepositoryData();
+    if (Strings.isNullOrEmpty(entityIdType)
+        && Strings.isNullOrEmpty(entityType)
+        && Strings.isNullOrEmpty(entityPackageName)) {
+      jpaRepositoryData = this.prepareData(tsFile, cwd);
+      if (jpaRepositoryData == null) {
+        return DataTransferObject.error("Could not extract repository data from entity file.");
+      }
+    } else {
+      jpaRepositoryData =
+          this.buildJPARepositoryData(cwd, entityType, entityIdType, entityPackageName);
+      if (jpaRepositoryData == null) {
+        return DataTransferObject.error("Unable to gather necessary repository data.");
+      }
+    }
+    DataTransferObject<CreateNewFileResponse> createFileResult =
+        this.createRepositoryFile(jpaRepositoryData);
+    if (!createFileResult.getSucceed()) {
+      return DataTransferObject.error(createFileResult.getErrorReason());
+    }
+    CreateJPARepositoryResponse response =
+        CreateJPARepositoryResponse.builder()
+            .filePath(createFileResult.getData().getFilePath())
+            .requiresSymbolSource(false)
+            .build();
+    return DataTransferObject.success(response);
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -80,7 +80,7 @@ public class CreateJPARepositoryCommandService {
       Path cwd, TSFile tsFile, TSNode publicClassNode) {
     Optional<TSNode> idFieldNode = this.getIdFieldFromEntity(tsFile, publicClassNode);
     if (idFieldNode.isPresent()) {
-      return IdFieldSearchResult.found(idFieldNode.get());
+      return IdFieldSearchResult.found(tsFile, idFieldNode.get());
     }
     Optional<TSNode> superClassNameNode =
         this.javaLanguageService
@@ -167,7 +167,7 @@ public class CreateJPARepositoryCommandService {
         String.format(
             "package %s;\n\nimport org.springframework.data.jpa.repository.JpaRepository;\nimport"
                 + " org.springframework.stereotype.Repository;\n\n@Repository\npublic interface"
-                + " %sRepository extends JpaRepository<%s, %s> {}",
+                + " %s extends JpaRepository<%s, %s> {}",
             jpaRepositoryData.getPackageName(),
             repositoryName,
             jpaRepositoryData.getEntityType(),

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/IdFieldSearchResult.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/IdFieldSearchResult.java
@@ -1,0 +1,30 @@
+package io.github.syntaxpresso.core.service.java.command.extra;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.treesitter.TSNode;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IdFieldSearchResult {
+  private final TSNode idFieldNode;
+  private final String missingSuperclassName;
+  private final boolean found;
+
+  public static IdFieldSearchResult found(TSNode idFieldNode) {
+    return new IdFieldSearchResult(idFieldNode, null, true);
+  }
+
+  public static IdFieldSearchResult missingSuperclass(String superclassName) {
+    return new IdFieldSearchResult(null, superclassName, false);
+  }
+
+  public static IdFieldSearchResult notFound() {
+    return new IdFieldSearchResult(null, null, false);
+  }
+
+  public boolean hasMissingSuperclass() {
+    return missingSuperclassName != null;
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/IdFieldSearchResult.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/IdFieldSearchResult.java
@@ -1,5 +1,6 @@
 package io.github.syntaxpresso.core.service.java.command.extra;
 
+import io.github.syntaxpresso.core.common.TSFile;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,20 +9,22 @@ import org.treesitter.TSNode;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IdFieldSearchResult {
+  private final TSFile tsFile;
   private final TSNode idFieldNode;
+  private final String idFieldType;
   private final String missingSuperclassName;
   private final boolean found;
 
-  public static IdFieldSearchResult found(TSNode idFieldNode) {
-    return new IdFieldSearchResult(idFieldNode, null, true);
+  public static IdFieldSearchResult found(TSFile tsFile, TSNode idFieldNode) {
+    return new IdFieldSearchResult(tsFile, idFieldNode, null, null, true);
   }
 
   public static IdFieldSearchResult missingSuperclass(String superclassName) {
-    return new IdFieldSearchResult(null, superclassName, false);
+    return new IdFieldSearchResult(null, null, null, superclassName, false);
   }
 
   public static IdFieldSearchResult notFound() {
-    return new IdFieldSearchResult(null, null, false);
+    return new IdFieldSearchResult(null, null, null, null, false);
   }
 
   public boolean hasMissingSuperclass() {

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/IdFieldSearchResult.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/IdFieldSearchResult.java
@@ -11,20 +11,19 @@ import org.treesitter.TSNode;
 public class IdFieldSearchResult {
   private final TSFile tsFile;
   private final TSNode idFieldNode;
-  private final String idFieldType;
   private final String missingSuperclassName;
   private final boolean found;
 
   public static IdFieldSearchResult found(TSFile tsFile, TSNode idFieldNode) {
-    return new IdFieldSearchResult(tsFile, idFieldNode, null, null, true);
+    return new IdFieldSearchResult(tsFile, idFieldNode, null, true);
   }
 
   public static IdFieldSearchResult missingSuperclass(String superclassName) {
-    return new IdFieldSearchResult(null, null, null, superclassName, false);
+    return new IdFieldSearchResult(null, null, superclassName, false);
   }
 
   public static IdFieldSearchResult notFound() {
-    return new IdFieldSearchResult(null, null, null, null, false);
+    return new IdFieldSearchResult(null, null, null, false);
   }
 
   public boolean hasMissingSuperclass() {

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/JPARepositoryData.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/JPARepositoryData.java
@@ -1,5 +1,7 @@
 package io.github.syntaxpresso.core.service.java.command.extra;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.nio.file.Path;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,10 +12,20 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY, setterVisibility = JsonAutoDetect.Visibility.PUBLIC_ONLY)
 public class JPARepositoryData {
+  @JsonProperty("path")
   private Path path;
+  
+  @JsonProperty("cwd")
   private Path cwd;
+  
+  @JsonProperty("packageName")
   private String packageName;
+  
+  @JsonProperty("entityIdType")
   private String entityIdType;
+  
+  @JsonProperty("entityType")
   private String entityType;
 }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/JPARepositoryData.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/JPARepositoryData.java
@@ -1,0 +1,19 @@
+package io.github.syntaxpresso.core.service.java.command.extra;
+
+import java.nio.file.Path;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JPARepositoryData {
+  private Path path;
+  private Path cwd;
+  private String packageName;
+  private String entityIdType;
+  private String entityType;
+}

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/PrepareDataResult.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/extra/PrepareDataResult.java
@@ -1,0 +1,82 @@
+package io.github.syntaxpresso.core.service.java.command.extra;
+
+import io.github.syntaxpresso.core.command.dto.CreateJPARepositoryResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Represents the result of preparing JPA repository data.
+ * Can represent success with repository data, requirement for external symbol source,
+ * or an error condition.
+ */
+@Getter
+@RequiredArgsConstructor
+public class PrepareDataResult {
+  private final JPARepositoryData repositoryData;
+  private final CreateJPARepositoryResponse requiresSymbolResponse;
+  private final String errorMessage;
+  private final ResultType type;
+
+  public enum ResultType {
+    SUCCESS,
+    REQUIRES_SYMBOL_SOURCE,
+    ERROR
+  }
+
+  /**
+   * Creates a successful result with repository data.
+   *
+   * @param repositoryData the prepared JPA repository data
+   * @return a success result
+   */
+  public static PrepareDataResult success(JPARepositoryData repositoryData) {
+    return new PrepareDataResult(repositoryData, null, null, ResultType.SUCCESS);
+  }
+
+  /**
+   * Creates a result indicating that external symbol source is required.
+   *
+   * @param response the response containing symbol information
+   * @return a requires symbol source result
+   */
+  public static PrepareDataResult requiresSymbolSource(CreateJPARepositoryResponse response) {
+    return new PrepareDataResult(null, response, null, ResultType.REQUIRES_SYMBOL_SOURCE);
+  }
+
+  /**
+   * Creates an error result with the specified error message.
+   *
+   * @param errorMessage the error message
+   * @return an error result
+   */
+  public static PrepareDataResult error(String errorMessage) {
+    return new PrepareDataResult(null, null, errorMessage, ResultType.ERROR);
+  }
+
+  /**
+   * Checks if this result represents a successful operation.
+   *
+   * @return true if successful, false otherwise
+   */
+  public boolean isSuccess() {
+    return this.type == ResultType.SUCCESS;
+  }
+
+  /**
+   * Checks if this result requires external symbol source.
+   *
+   * @return true if requires symbol source, false otherwise
+   */
+  public boolean requiresSymbolSource() {
+    return this.type == ResultType.REQUIRES_SYMBOL_SOURCE;
+  }
+
+  /**
+   * Checks if this result represents an error.
+   *
+   * @return true if error, false otherwise
+   */
+  public boolean isError() {
+    return this.type == ResultType.ERROR;
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationService.java
@@ -429,6 +429,7 @@ public class AnnotationService {
     String nodeType = declarationNode.getType();
     if (!nodeType.equals("class_declaration")
         && !nodeType.equals("field_declaration")
+        && !nodeType.equals("interface_declaration")
         && !nodeType.equals("method_declaration")) {
       return null;
     }
@@ -518,6 +519,7 @@ public class AnnotationService {
     String nodeType = declarationNode.getType();
     if (!nodeType.equals("class_declaration")
         && !nodeType.equals("field_declaration")
+        && !nodeType.equals("interface_declaration")
         && !nodeType.equals("method_declaration")) {
       return;
     }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/ClassDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/ClassDeclarationService.java
@@ -303,6 +303,7 @@ public class ClassDeclarationService {
 
   /**
    * Gets the public class of a file, defined as the public class whose name matches the file name.
+   * If the file name is not available, falls back to finding the first public class.
    *
    * <p>Usage example:
    *
@@ -325,7 +326,7 @@ public class ClassDeclarationService {
     }
     Optional<String> fileName = tsFile.getFileNameWithoutExtension();
     if (fileName.isEmpty()) {
-      return Optional.empty();
+      return this.getFirstPublicClass(tsFile);
     }
     return this.findClassByName(tsFile, fileName.get());
   }
@@ -382,6 +383,35 @@ public class ClassDeclarationService {
     // Note: Import resolution would require ImportDeclarationService, but for now
     // we'll assume same package for simplicity
     return Optional.of(superclassName); // Simplified - just return the simple name
+  }
+
+  /**
+   * Gets the first public class declaration found in the file. This is useful when the file path is
+   * not available but you need to find the main class.
+   *
+   * @param tsFile The {@link TSFile} to analyze
+   * @return Optional containing the first public class declaration node, empty if none found
+   */
+  private Optional<TSNode> getFirstPublicClass(TSFile tsFile) {
+    String queryString =
+        """
+        (class_declaration
+          (modifiers) @modifiers
+          name: (identifier) @className
+        ) @classDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile.query(queryString).returningAllCaptures().execute().captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode modifiers = result.get("modifiers");
+      if (modifiers != null) {
+        String modifierText = tsFile.getTextFromNode(modifiers);
+        if (modifierText.contains("public")) {
+          return Optional.of(result.get("classDeclaration"));
+        }
+      }
+    }
+    return Optional.empty();
   }
 
   /**

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/InterfaceDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/InterfaceDeclarationService.java
@@ -1,0 +1,157 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import com.google.common.base.Strings;
+import io.github.syntaxpresso.core.common.TSFile;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.treesitter.TSNode;
+
+@Getter
+@RequiredArgsConstructor
+public class InterfaceDeclarationService {
+
+  /**
+   * Finds an interface declaration node by its name.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> interfaceNode = service.findInterfaceByName(tsFile, "MyInterface");
+   * if (interfaceNode.isPresent()) {
+   *   String interfaceDecl = tsFile.getTextFromNode(interfaceNode.get());
+   *   // interfaceDecl = "public interface MyInterface extends BaseInterface { void method(); }"
+   * }
+   * </pre>
+   *
+   * @param tsFile {@link TSFile} containing the source code
+   * @param interfaceName Name of the interface to search for
+   * @return {@link Optional} containing the interface declaration node, or empty if not found,
+   *     file/tree is null, or interfaceName is empty
+   */
+  public Optional<TSNode> findInterfaceByName(TSFile tsFile, String interfaceName) {
+    if (tsFile == null || tsFile.getTree() == null || Strings.isNullOrEmpty(interfaceName)) {
+      return Optional.empty();
+    }
+    String queryString =
+        String.format(
+            """
+            (interface_declaration
+              name: (identifier) @interfaceName
+            (#eq? @interfaceName "%s")) @interfaceDeclaration
+            """,
+            interfaceName);
+    return tsFile
+        .query(queryString)
+        .returning("interfaceDeclaration")
+        .execute()
+        .firstNodeOptional();
+  }
+
+  /**
+   * Gets the public interface of a file, defined as the public interface whose name matches the
+   * file name. If the file name is not available, falls back to finding the first public interface.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * // For a file named "MyInterface.java"
+   * Optional<TSNode> publicInterface = service.getPublicInterface(tsFile);
+   * if (publicInterface.isPresent()) {
+   *   String interfaceDecl = tsFile.getTextFromNode(publicInterface.get());
+   *   // interfaceDecl = "public interface MyInterface ..."
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} to analyze.
+   * @return An {@link Optional} containing the public interface declaration node, or empty if not
+   *     found, file/tree is null, or file name is missing.
+   */
+  public Optional<TSNode> getPublicInterface(TSFile tsFile) {
+    if (tsFile == null || tsFile.getTree() == null) {
+      return Optional.empty();
+    }
+    Optional<String> fileName = tsFile.getFileNameWithoutExtension();
+    if (fileName.isEmpty()) {
+      return this.getFirstPublicInterface(tsFile);
+    }
+    return this.findInterfaceByName(tsFile, fileName.get());
+  }
+
+  /**
+   * Gets the name identifier node from an interface declaration.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> nameNode = service.getInterfaceNameNode(tsFile, interfaceNode);
+   * if (nameNode.isPresent()) {
+   *   String interfaceName = tsFile.getTextFromNode(nameNode.get());
+   *   // interfaceName = "MyInterface"
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} containing the interface declaration
+   * @param interfaceDeclarationNode The interface declaration node to analyze
+   * @return Optional containing the interface name identifier node if found, empty otherwise
+   */
+  public Optional<TSNode> getInterfaceNameNode(TSFile tsFile, TSNode interfaceDeclarationNode) {
+    if (tsFile == null
+        || tsFile.getTree() == null
+        || !interfaceDeclarationNode.getType().equals("interface_declaration")) {
+      return Optional.empty();
+    }
+    String queryString =
+        """
+        (interface_declaration
+          name: (identifier) @interfaceName
+        ) @interfaceDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile
+            .query(queryString)
+            .within(interfaceDeclarationNode)
+            .returningAllCaptures()
+            .execute()
+            .captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode nameNode = result.get("interfaceName");
+      if (nameNode != null) {
+        return Optional.of(nameNode);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Gets the first public interface declaration found in the file. This is useful when the file
+   * path is not available but you need to find the main interface.
+   *
+   * @param tsFile The {@link TSFile} to analyze
+   * @return Optional containing the first public interface declaration node, empty if none found
+   */
+  private Optional<TSNode> getFirstPublicInterface(TSFile tsFile) {
+    String queryString =
+        """
+        (interface_declaration
+          (modifiers) @modifiers
+          name: (identifier) @interfaceName
+        ) @interfaceDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile.query(queryString).returningAllCaptures().execute().captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode modifiers = result.get("modifiers");
+      if (modifiers != null) {
+        String modifierText = tsFile.getTextFromNode(modifiers);
+        if (modifierText.contains("public")) {
+          return Optional.of(result.get("interfaceDeclaration"));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+}
+

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/extra/InterfaceCapture.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/extra/InterfaceCapture.java
@@ -1,0 +1,66 @@
+package io.github.syntaxpresso.core.service.java.language.extra;
+
+/**
+ * Enum representing all capture groups from the Tree-sitter query for Java interface declarations.
+ * Each enum constant corresponds to a @capture in the query.
+ */
+public enum InterfaceCapture {
+  // Corresponds to the captures in the associated query
+  INTERFACE("interface"),
+  MODIFIERS("modifiers"),
+  INTERFACE_ANNOTATION("interfaceAnnotation"),
+  INTERFACE_NAME("interfaceName"),
+  INTERFACE_EXTENDS("interfaceExtends"),
+  INTERFACE_BODY("interfaceBody");
+
+  private final String captureName;
+
+  InterfaceCapture(String captureName) {
+    this.captureName = captureName;
+  }
+
+  /**
+   * Get the capture name as it appears in the Tree-sitter query (without the @ symbol).
+   *
+   * @return the capture name
+   */
+  public String getCaptureName() {
+    return captureName;
+  }
+
+  /**
+   * Get the capture name with the @ symbol prefix as used in Tree-sitter queries.
+   *
+   * @return the capture name with @ prefix
+   */
+  public String getCaptureWithAt() {
+    return "@" + captureName;
+  }
+
+  /**
+   * Find an InterfaceCapture by its capture name.
+   *
+   * @param captureName the name to search for (with or without @ prefix)
+   * @return the matching InterfaceCapture, or null if not found
+   */
+  public static InterfaceCapture fromCaptureName(String captureName) {
+    if (captureName == null) {
+      return null;
+    }
+
+    // Remove @ prefix if present
+    String cleanName = captureName.startsWith("@") ? captureName.substring(1) : captureName;
+
+    for (InterfaceCapture capture : values()) {
+      if (capture.captureName.equals(cleanName)) {
+        return capture;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return captureName;
+  }
+}

--- a/src/main/resources/META-INF/native-image/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/reachability-metadata.json
@@ -120,6 +120,36 @@
       ]
     },
     {
+      "type": "io.github.syntaxpresso.core.command.dto.CreateJPARepositoryResponse",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": ["java.lang.String", "java.lang.Boolean", "java.lang.String", "io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData"]
+        }
+      ]
+    },
+    {
+      "type": "io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": ["java.nio.file.Path", "java.nio.file.Path", "java.lang.String", "java.lang.String", "java.lang.String"]
+        }
+      ]
+    },
+    {
       "type": "io.github.syntaxpresso.core.service.extra.JavaIdentifierType",
       "allDeclaredFields": true,
       "allDeclaredMethods": true

--- a/src/test/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommandTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommandTest.java
@@ -1,7 +1,6 @@
 package io.github.syntaxpresso.core.command;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.syntaxpresso.core.command.dto.CreateJPARepositoryResponse;
 import io.github.syntaxpresso.core.common.DataTransferObject;
@@ -9,7 +8,6 @@ import io.github.syntaxpresso.core.common.extra.SupportedIDE;
 import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.java.command.CreateJPARepositoryCommandService;
 import io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -22,8 +20,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Comprehensive tests for CreateJPARepositoryCommand.
- * 
- * Example usage:
+ *
+ * <p>Example usage:
+ *
  * <pre>
  * CreateJPARepositoryCommand command = new CreateJPARepositoryCommand(service);
  * // Set command options: --cwd /path/to/project --file-path Entity.java --language JAVA --ide NONE
@@ -47,11 +46,14 @@ class CreateJPARepositoryCommandTest {
     this.createJPARepositoryCommand = new CreateJPARepositoryCommand(this.testService);
   }
 
-  /**
-   * Helper method to setup command parameters using reflection
-   */
-  private void setupCreateJPARepositoryCommand(Path cwd, Path filePath, SupportedLanguage language, 
-      SupportedIDE ide, String superclassSource) throws Exception {
+  /** Helper method to setup command parameters using reflection */
+  private void setupCreateJPARepositoryCommand(
+      Path cwd,
+      Path filePath,
+      SupportedLanguage language,
+      SupportedIDE ide,
+      String superclassSource)
+      throws Exception {
     var cwdField = CreateJPARepositoryCommand.class.getDeclaredField("cwd");
     cwdField.setAccessible(true);
     cwdField.set(this.createJPARepositoryCommand, cwd);
@@ -69,7 +71,8 @@ class CreateJPARepositoryCommandTest {
     ideField.set(this.createJPARepositoryCommand, ide);
 
     if (superclassSource != null) {
-      var superclassSourceField = CreateJPARepositoryCommand.class.getDeclaredField("superclassSource");
+      var superclassSourceField =
+          CreateJPARepositoryCommand.class.getDeclaredField("superclassSource");
       superclassSourceField.setAccessible(true);
       superclassSourceField.set(this.createJPARepositoryCommand, superclassSource);
     }
@@ -83,19 +86,22 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should have correct picocli annotations")
     void shouldHaveCorrectPicocliAnnotations() {
       // Given & When
-      var commandAnnotation = CreateJPARepositoryCommand.class.getAnnotation(picocli.CommandLine.Command.class);
+      var commandAnnotation =
+          CreateJPARepositoryCommand.class.getAnnotation(picocli.CommandLine.Command.class);
 
       // Then
       assertNotNull(commandAnnotation);
       assertEquals("create-jpa-repository", commandAnnotation.name());
-      assertEquals("Create JPA Repository for the current JPA Entity.", commandAnnotation.description()[0]);
+      assertEquals(
+          "Create JPA Repository for the current JPA Entity.", commandAnnotation.description()[0]);
     }
 
     @Test
     @DisplayName("Should return DataTransferObject with correct generic type")
     void shouldReturnDataTransferObjectWithCorrectGenericType() {
       // Given & When
-      boolean implementsCallable = Callable.class.isAssignableFrom(CreateJPARepositoryCommand.class);
+      boolean implementsCallable =
+          Callable.class.isAssignableFrom(CreateJPARepositoryCommand.class);
 
       // Then
       assertTrue(implementsCallable);
@@ -105,15 +111,16 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle all required options")
     void shouldHandleAllRequiredOptions() throws Exception {
       // Given
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/path/UserRepository.java")
-          .requiresSymbolSource(false)
-          .symbol(null)
-          .repositoryData(null)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/path/UserRepository.java")
+              .requiresSymbolSource(false)
+              .symbol(null)
+              .repositoryData(null)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.NONE, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -139,13 +146,18 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should process Java language successfully")
     void shouldProcessJavaLanguageSuccessfully() throws Exception {
       // Given
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/UserRepository.java")
-          .requiresSymbolSource(false)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/UserRepository.java")
+              .requiresSymbolSource(false)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.VSCODE, "public class BaseEntity {}");
+      setupCreateJPARepositoryCommand(
+          tempDir,
+          Paths.get("User.java"),
+          SupportedLanguage.JAVA,
+          SupportedIDE.VSCODE,
+          "public class BaseEntity {}");
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -164,7 +176,7 @@ class CreateJPARepositoryCommandTest {
       // Test the case where language field is null (simulates unsupported language)
       Path javaFile = tempDir.resolve("test.java");
       Files.write(javaFile, "public class Test {}".getBytes());
-      
+
       setField(createJPARepositoryCommand, "cwd", tempDir);
       setField(createJPARepositoryCommand, "filePath", javaFile);
       setField(createJPARepositoryCommand, "language", null); // Simulate unsupported language
@@ -185,13 +197,14 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle NONE IDE correctly")
     void shouldHandleNoneIDECorrectly() throws Exception {
       // Given
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/UserRepository.java")
-          .requiresSymbolSource(false)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/UserRepository.java")
+              .requiresSymbolSource(false)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.NONE, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -205,13 +218,14 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle VSCODE IDE correctly")
     void shouldHandleVscodeIDECorrectly() throws Exception {
       // Given
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/UserRepository.java")
-          .requiresSymbolSource(false)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/UserRepository.java")
+              .requiresSymbolSource(false)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.VSCODE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.VSCODE, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -225,13 +239,14 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle NEOVIM IDE correctly")
     void shouldHandleNeovimIDECorrectly() throws Exception {
       // Given
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/UserRepository.java")
-          .requiresSymbolSource(false)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/UserRepository.java")
+              .requiresSymbolSource(false)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NEOVIM, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.NEOVIM, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -250,21 +265,23 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should successfully create JPA repository for Java language")
     void shouldSuccessfullyCreateJPARepositoryForJavaLanguage() throws Exception {
       // Given
-      JPARepositoryData repositoryData = JPARepositoryData.builder()
-          .cwd(tempDir)
-          .packageName("com.example.repository")
-          .entityType("User")
-          .entityIdType("Long")
-          .build();
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/com/example/repository/UserRepository.java")
-          .requiresSymbolSource(false)
-          .symbol(null)
-          .repositoryData(repositoryData)
-          .build();
+      JPARepositoryData repositoryData =
+          JPARepositoryData.builder()
+              .cwd(tempDir)
+              .packageName("com.example.repository")
+              .entityType("User")
+              .entityIdType("Long")
+              .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/com/example/repository/UserRepository.java")
+              .requiresSymbolSource(false)
+              .symbol(null)
+              .repositoryData(repositoryData)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.NONE, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -285,8 +302,12 @@ class CreateJPARepositoryCommandTest {
     void shouldHandleServiceErrorResponsesForJava() throws Exception {
       // Given
       testService.setErrorResponse("No public class found in the entity file.");
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("InvalidEntity.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir,
+          Paths.get("InvalidEntity.java"),
+          SupportedLanguage.JAVA,
+          SupportedIDE.NONE,
+          null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -302,21 +323,23 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle repository creation requiring symbol source")
     void shouldHandleRepositoryCreationRequiringSymbolSource() throws Exception {
       // Given
-      JPARepositoryData repositoryData = JPARepositoryData.builder()
-          .cwd(tempDir)
-          .packageName("com.example.repository")
-          .entityType("User")
-          .entityIdType("Long")
-          .build();
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/com/example/repository/UserRepository.java")
-          .requiresSymbolSource(true)
-          .symbol("BaseEntity")
-          .repositoryData(repositoryData)
-          .build();
+      JPARepositoryData repositoryData =
+          JPARepositoryData.builder()
+              .cwd(tempDir)
+              .packageName("com.example.repository")
+              .entityType("User")
+              .entityIdType("Long")
+              .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/com/example/repository/UserRepository.java")
+              .requiresSymbolSource(true)
+              .symbol("BaseEntity")
+              .repositoryData(repositoryData)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.NONE, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -333,41 +356,48 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle complex entity with superclass source")
     void shouldHandleComplexEntityWithSuperclassSource() throws Exception {
       // Given
-      String superclassSource = """
+      String superclassSource =
+          """
           package com.example.base;
-          
+
           import jakarta.persistence.*;
-          
+
           @MappedSuperclass
           public abstract class BaseEntity {
               @Id
               @GeneratedValue(strategy = GenerationType.IDENTITY)
               private Long id;
-              
+
               public Long getId() {
                   return id;
               }
-              
+
               public void setId(Long id) {
                   this.id = id;
               }
           }
           """;
-      JPARepositoryData repositoryData = JPARepositoryData.builder()
-          .cwd(tempDir)
-          .packageName("com.example.repository")
-          .entityType("User")
-          .entityIdType("Long")
-          .build();
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/com/example/repository/UserRepository.java")
-          .requiresSymbolSource(false)
-          .symbol(null)
-          .repositoryData(repositoryData)
-          .build();
+      JPARepositoryData repositoryData =
+          JPARepositoryData.builder()
+              .cwd(tempDir)
+              .packageName("com.example.repository")
+              .entityType("User")
+              .entityIdType("Long")
+              .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/com/example/repository/UserRepository.java")
+              .requiresSymbolSource(false)
+              .symbol(null)
+              .repositoryData(repositoryData)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.VSCODE, superclassSource);
+      setupCreateJPARepositoryCommand(
+          tempDir,
+          Paths.get("User.java"),
+          SupportedLanguage.JAVA,
+          SupportedIDE.VSCODE,
+          superclassSource);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -389,8 +419,8 @@ class CreateJPARepositoryCommandTest {
     void shouldHandleServiceReturningNullResponse() throws Exception {
       // Given
       testService.setNullResponse();
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.NONE, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -404,13 +434,14 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle empty superclass source")
     void shouldHandleEmptySuperclassSource() throws Exception {
       // Given
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/UserRepository.java")
-          .requiresSymbolSource(false)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/UserRepository.java")
+              .requiresSymbolSource(false)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, "");
+      setupCreateJPARepositoryCommand(
+          tempDir, Paths.get("User.java"), SupportedLanguage.JAVA, SupportedIDE.NONE, "");
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -425,14 +456,15 @@ class CreateJPARepositoryCommandTest {
     @DisplayName("Should handle complex file paths")
     void shouldHandleComplexFilePaths() throws Exception {
       // Given
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/path/with spaces/UserRepository.java")
-          .requiresSymbolSource(false)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/path/with spaces/UserRepository.java")
+              .requiresSymbolSource(false)
+              .build();
       testService.setSuccessResponse(expectedResponse);
       Path complexPath = Paths.get("path with spaces", "User Entity.java");
-      setupCreateJPARepositoryCommand(tempDir, complexPath, 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir, complexPath, SupportedLanguage.JAVA, SupportedIDE.NONE, null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -448,13 +480,18 @@ class CreateJPARepositoryCommandTest {
     void shouldHandleDifferentWorkingDirectories() throws Exception {
       // Given
       Path customWorkingDir = tempDir.resolve("custom").resolve("project");
-      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
-          .filePath("/test/UserRepository.java")
-          .requiresSymbolSource(false)
-          .build();
+      CreateJPARepositoryResponse expectedResponse =
+          CreateJPARepositoryResponse.builder()
+              .filePath("/test/UserRepository.java")
+              .requiresSymbolSource(false)
+              .build();
       testService.setSuccessResponse(expectedResponse);
-      setupCreateJPARepositoryCommand(customWorkingDir, Paths.get("User.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NEOVIM, null);
+      setupCreateJPARepositoryCommand(
+          customWorkingDir,
+          Paths.get("User.java"),
+          SupportedLanguage.JAVA,
+          SupportedIDE.NEOVIM,
+          null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -471,8 +508,12 @@ class CreateJPARepositoryCommandTest {
     void shouldHandleServiceValidationErrors() throws Exception {
       // Given
       testService.setErrorResponse("Package name could not be extracted from the entity file.");
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("InvalidEntity.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.VSCODE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir,
+          Paths.get("InvalidEntity.java"),
+          SupportedLanguage.JAVA,
+          SupportedIDE.VSCODE,
+          null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -480,7 +521,8 @@ class CreateJPARepositoryCommandTest {
       // Then
       assertFalse(result.getSucceed());
       assertNull(result.getData());
-      assertEquals("Package name could not be extracted from the entity file.", result.getErrorReason());
+      assertEquals(
+          "Package name could not be extracted from the entity file.", result.getErrorReason());
       assertTrue(testService.wasServiceCalled());
     }
 
@@ -489,8 +531,12 @@ class CreateJPARepositoryCommandTest {
     void shouldHandleIdFieldTypeExtractionErrors() throws Exception {
       // Given
       testService.setErrorResponse("ID field type could not be extracted.");
-      setupCreateJPARepositoryCommand(tempDir, Paths.get("EntityWithoutIdType.java"), 
-          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+      setupCreateJPARepositoryCommand(
+          tempDir,
+          Paths.get("EntityWithoutIdType.java"),
+          SupportedLanguage.JAVA,
+          SupportedIDE.NONE,
+          null);
 
       // When
       DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
@@ -503,9 +549,7 @@ class CreateJPARepositoryCommandTest {
     }
   }
 
-  /**
-   * Helper method to set private fields using reflection for testing purposes.
-   */
+  /** Helper method to set private fields using reflection for testing purposes. */
   private void setField(Object target, String fieldName, Object value) {
     try {
       var field = target.getClass().getDeclaredField(fieldName);
@@ -516,13 +560,12 @@ class CreateJPARepositoryCommandTest {
     }
   }
 
-  /**
-   * Test double for CreateJPARepositoryCommandService to control service behavior in tests.
-   */
-  private static class TestCreateJPARepositoryCommandService extends CreateJPARepositoryCommandService {
+  /** Test double for CreateJPARepositoryCommandService to control service behavior in tests. */
+  private static class TestCreateJPARepositoryCommandService
+      extends CreateJPARepositoryCommandService {
     private DataTransferObject<CreateJPARepositoryResponse> responseToReturn;
     private boolean serviceCalled = false;
-    
+
     // Track last called parameters
     private Path lastCalledCwd;
     private Path lastCalledFilePath;
@@ -535,8 +578,12 @@ class CreateJPARepositoryCommandTest {
     }
 
     @Override
-    public DataTransferObject<CreateJPARepositoryResponse> run(Path cwd, Path filePath, 
-        SupportedLanguage language, SupportedIDE ide, String superclassSource) {
+    public DataTransferObject<CreateJPARepositoryResponse> run(
+        Path cwd,
+        Path filePath,
+        SupportedLanguage language,
+        SupportedIDE ide,
+        String superclassSource) {
       this.serviceCalled = true;
       this.lastCalledCwd = cwd;
       this.lastCalledFilePath = filePath;
@@ -583,3 +630,4 @@ class CreateJPARepositoryCommandTest {
     }
   }
 }
+

--- a/src/test/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommandTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommandTest.java
@@ -1,0 +1,585 @@
+package io.github.syntaxpresso.core.command;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.syntaxpresso.core.command.dto.CreateJPARepositoryResponse;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.command.CreateJPARepositoryCommandService;
+import io.github.syntaxpresso.core.service.java.command.extra.JPARepositoryData;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.Callable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Comprehensive tests for CreateJPARepositoryCommand.
+ * 
+ * Example usage:
+ * <pre>
+ * CreateJPARepositoryCommand command = new CreateJPARepositoryCommand(service);
+ * // Set command options: --cwd /path/to/project --file-path Entity.java --language JAVA --ide NONE
+ * DataTransferObject&lt;CreateJPARepositoryResponse&gt; result = command.call();
+ * if (result.getSucceed()) {
+ *     CreateJPARepositoryResponse response = result.getData();
+ *     System.out.println("Created repository: " + response.getFilePath());
+ * }
+ * </pre>
+ */
+@DisplayName("CreateJPARepositoryCommand Tests")
+class CreateJPARepositoryCommandTest {
+  private CreateJPARepositoryCommand createJPARepositoryCommand;
+  private TestCreateJPARepositoryCommandService testService;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    this.testService = new TestCreateJPARepositoryCommandService();
+    this.createJPARepositoryCommand = new CreateJPARepositoryCommand(this.testService);
+  }
+
+  /**
+   * Helper method to setup command parameters using reflection
+   */
+  private void setupCreateJPARepositoryCommand(Path cwd, Path filePath, SupportedLanguage language, 
+      SupportedIDE ide, String superclassSource) throws Exception {
+    var cwdField = CreateJPARepositoryCommand.class.getDeclaredField("cwd");
+    cwdField.setAccessible(true);
+    cwdField.set(this.createJPARepositoryCommand, cwd);
+
+    var filePathField = CreateJPARepositoryCommand.class.getDeclaredField("filePath");
+    filePathField.setAccessible(true);
+    filePathField.set(this.createJPARepositoryCommand, filePath);
+
+    var languageField = CreateJPARepositoryCommand.class.getDeclaredField("language");
+    languageField.setAccessible(true);
+    languageField.set(this.createJPARepositoryCommand, language);
+
+    var ideField = CreateJPARepositoryCommand.class.getDeclaredField("ide");
+    ideField.setAccessible(true);
+    ideField.set(this.createJPARepositoryCommand, ide);
+
+    if (superclassSource != null) {
+      var superclassSourceField = CreateJPARepositoryCommand.class.getDeclaredField("superclassSource");
+      superclassSourceField.setAccessible(true);
+      superclassSourceField.set(this.createJPARepositoryCommand, superclassSource);
+    }
+  }
+
+  @Nested
+  @DisplayName("Command configuration tests")
+  class CommandConfigurationTests {
+
+    @Test
+    @DisplayName("Should have correct picocli annotations")
+    void shouldHaveCorrectPicocliAnnotations() {
+      // Given & When
+      var commandAnnotation = CreateJPARepositoryCommand.class.getAnnotation(picocli.CommandLine.Command.class);
+
+      // Then
+      assertNotNull(commandAnnotation);
+      assertEquals("create-jpa-repository", commandAnnotation.name());
+      assertEquals("Create JPA Repository for the current JPA Entity.", commandAnnotation.description()[0]);
+    }
+
+    @Test
+    @DisplayName("Should return DataTransferObject with correct generic type")
+    void shouldReturnDataTransferObjectWithCorrectGenericType() {
+      // Given & When
+      boolean implementsCallable = Callable.class.isAssignableFrom(CreateJPARepositoryCommand.class);
+
+      // Then
+      assertTrue(implementsCallable);
+    }
+
+    @Test
+    @DisplayName("Should handle all required options")
+    void shouldHandleAllRequiredOptions() throws Exception {
+      // Given
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/path/UserRepository.java")
+          .requiresSymbolSource(false)
+          .symbol(null)
+          .repositoryData(null)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals("/test/path/UserRepository.java", result.getData().getFilePath());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(tempDir, testService.getLastCalledCwd());
+      assertEquals(Paths.get("User.java"), testService.getLastCalledFilePath());
+      assertEquals(SupportedLanguage.JAVA, testService.getLastCalledLanguage());
+      assertEquals(SupportedIDE.NONE, testService.getLastCalledIDE());
+      assertNull(testService.getLastCalledSuperclassSource());
+    }
+  }
+
+  @Nested
+  @DisplayName("Language validation tests")
+  class LanguageValidationTests {
+
+    @Test
+    @DisplayName("Should process Java language successfully")
+    void shouldProcessJavaLanguageSuccessfully() throws Exception {
+      // Given
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/UserRepository.java")
+          .requiresSymbolSource(false)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.VSCODE, "public class BaseEntity {}");
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals("public class BaseEntity {}", testService.getLastCalledSuperclassSource());
+    }
+
+    @Test
+    @DisplayName("Should return error for non-Java language")
+    void shouldReturnErrorForNonJavaLanguage() throws Exception {
+      // Given
+      // Test the case where language field is null (simulates unsupported language)
+      Path javaFile = tempDir.resolve("test.java");
+      Files.write(javaFile, "public class Test {}".getBytes());
+      
+      setField(createJPARepositoryCommand, "cwd", tempDir);
+      setField(createJPARepositoryCommand, "filePath", javaFile);
+      setField(createJPARepositoryCommand, "language", null); // Simulate unsupported language
+      setField(createJPARepositoryCommand, "ide", SupportedIDE.NONE);
+
+      // When & Then
+      // This should throw NullPointerException due to current implementation
+      assertThrows(NullPointerException.class, () -> createJPARepositoryCommand.call());
+      assertFalse(testService.wasServiceCalled());
+    }
+  }
+
+  @Nested
+  @DisplayName("IDE-specific behavior tests")
+  class IDESpecificBehaviorTests {
+
+    @Test
+    @DisplayName("Should handle NONE IDE correctly")
+    void shouldHandleNoneIDECorrectly() throws Exception {
+      // Given
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/UserRepository.java")
+          .requiresSymbolSource(false)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertEquals(SupportedIDE.NONE, testService.getLastCalledIDE());
+    }
+
+    @Test
+    @DisplayName("Should handle VSCODE IDE correctly")
+    void shouldHandleVscodeIDECorrectly() throws Exception {
+      // Given
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/UserRepository.java")
+          .requiresSymbolSource(false)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.VSCODE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertEquals(SupportedIDE.VSCODE, testService.getLastCalledIDE());
+    }
+
+    @Test
+    @DisplayName("Should handle NEOVIM IDE correctly")
+    void shouldHandleNeovimIDECorrectly() throws Exception {
+      // Given
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/UserRepository.java")
+          .requiresSymbolSource(false)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NEOVIM, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertEquals(SupportedIDE.NEOVIM, testService.getLastCalledIDE());
+    }
+  }
+
+  @Nested
+  @DisplayName("Java language support tests")
+  class JavaLanguageSupportTests {
+
+    @Test
+    @DisplayName("Should successfully create JPA repository for Java language")
+    void shouldSuccessfullyCreateJPARepositoryForJavaLanguage() throws Exception {
+      // Given
+      JPARepositoryData repositoryData = JPARepositoryData.builder()
+          .cwd(tempDir)
+          .packageName("com.example.repository")
+          .entityType("User")
+          .entityIdType("Long")
+          .build();
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/com/example/repository/UserRepository.java")
+          .requiresSymbolSource(false)
+          .symbol(null)
+          .repositoryData(repositoryData)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertTrue(result.getData().getFilePath().contains("UserRepository.java"));
+      assertFalse(result.getData().getRequiresSymbolSource());
+      assertNotNull(result.getData().getRepositoryData());
+      assertEquals("User", result.getData().getRepositoryData().getEntityType());
+      assertEquals("Long", result.getData().getRepositoryData().getEntityIdType());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle service error responses for Java")
+    void shouldHandleServiceErrorResponsesForJava() throws Exception {
+      // Given
+      testService.setErrorResponse("No public class found in the entity file.");
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("InvalidEntity.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertNull(result.getData());
+      assertEquals("No public class found in the entity file.", result.getErrorReason());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle repository creation requiring symbol source")
+    void shouldHandleRepositoryCreationRequiringSymbolSource() throws Exception {
+      // Given
+      JPARepositoryData repositoryData = JPARepositoryData.builder()
+          .cwd(tempDir)
+          .packageName("com.example.repository")
+          .entityType("User")
+          .entityIdType("Long")
+          .build();
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/com/example/repository/UserRepository.java")
+          .requiresSymbolSource(true)
+          .symbol("BaseEntity")
+          .repositoryData(repositoryData)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertTrue(result.getData().getRequiresSymbolSource());
+      assertEquals("BaseEntity", result.getData().getSymbol());
+      assertNotNull(result.getData().getRepositoryData());
+    }
+
+    @Test
+    @DisplayName("Should handle complex entity with superclass source")
+    void shouldHandleComplexEntityWithSuperclassSource() throws Exception {
+      // Given
+      String superclassSource = """
+          package com.example.base;
+          
+          import jakarta.persistence.*;
+          
+          @MappedSuperclass
+          public abstract class BaseEntity {
+              @Id
+              @GeneratedValue(strategy = GenerationType.IDENTITY)
+              private Long id;
+              
+              public Long getId() {
+                  return id;
+              }
+              
+              public void setId(Long id) {
+                  this.id = id;
+              }
+          }
+          """;
+      JPARepositoryData repositoryData = JPARepositoryData.builder()
+          .cwd(tempDir)
+          .packageName("com.example.repository")
+          .entityType("User")
+          .entityIdType("Long")
+          .build();
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/com/example/repository/UserRepository.java")
+          .requiresSymbolSource(false)
+          .symbol(null)
+          .repositoryData(repositoryData)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.VSCODE, superclassSource);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(superclassSource, testService.getLastCalledSuperclassSource());
+      assertTrue(testService.wasServiceCalled());
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge case tests")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("Should handle service returning null response")
+    void shouldHandleServiceReturningNullResponse() throws Exception {
+      // Given
+      testService.setNullResponse();
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertNull(result); // Service returned null, so command returns null
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle empty superclass source")
+    void shouldHandleEmptySuperclassSource() throws Exception {
+      // Given
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/UserRepository.java")
+          .requiresSymbolSource(false)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, "");
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertEquals("", testService.getLastCalledSuperclassSource());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle complex file paths")
+    void shouldHandleComplexFilePaths() throws Exception {
+      // Given
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/path/with spaces/UserRepository.java")
+          .requiresSymbolSource(false)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      Path complexPath = Paths.get("path with spaces", "User Entity.java");
+      setupCreateJPARepositoryCommand(tempDir, complexPath, 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertEquals(complexPath, testService.getLastCalledFilePath());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle different working directories")
+    void shouldHandleDifferentWorkingDirectories() throws Exception {
+      // Given
+      Path customWorkingDir = tempDir.resolve("custom").resolve("project");
+      CreateJPARepositoryResponse expectedResponse = CreateJPARepositoryResponse.builder()
+          .filePath("/test/UserRepository.java")
+          .requiresSymbolSource(false)
+          .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupCreateJPARepositoryCommand(customWorkingDir, Paths.get("User.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NEOVIM, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertEquals(customWorkingDir, testService.getLastCalledCwd());
+      assertEquals(SupportedIDE.NEOVIM, testService.getLastCalledIDE());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle service validation errors")
+    void shouldHandleServiceValidationErrors() throws Exception {
+      // Given
+      testService.setErrorResponse("Package name could not be extracted from the entity file.");
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("InvalidEntity.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.VSCODE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertNull(result.getData());
+      assertEquals("Package name could not be extracted from the entity file.", result.getErrorReason());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle ID field type extraction errors")
+    void shouldHandleIdFieldTypeExtractionErrors() throws Exception {
+      // Given
+      testService.setErrorResponse("ID field type could not be extracted.");
+      setupCreateJPARepositoryCommand(tempDir, Paths.get("EntityWithoutIdType.java"), 
+          SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<CreateJPARepositoryResponse> result = createJPARepositoryCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertNull(result.getData());
+      assertEquals("ID field type could not be extracted.", result.getErrorReason());
+      assertTrue(testService.wasServiceCalled());
+    }
+  }
+
+  /**
+   * Helper method to set private fields using reflection for testing purposes.
+   */
+  private void setField(Object target, String fieldName, Object value) {
+    try {
+      var field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set field: " + fieldName, e);
+    }
+  }
+
+  /**
+   * Test double for CreateJPARepositoryCommandService to control service behavior in tests.
+   */
+  private static class TestCreateJPARepositoryCommandService extends CreateJPARepositoryCommandService {
+    private DataTransferObject<CreateJPARepositoryResponse> responseToReturn;
+    private boolean serviceCalled = false;
+    
+    // Track last called parameters
+    private Path lastCalledCwd;
+    private Path lastCalledFilePath;
+    private SupportedLanguage lastCalledLanguage;
+    private SupportedIDE lastCalledIDE;
+    private String lastCalledSuperclassSource;
+
+    public TestCreateJPARepositoryCommandService() {
+      super(null, null); // Mock dependencies are not used in tests
+    }
+
+    @Override
+    public DataTransferObject<CreateJPARepositoryResponse> run(Path cwd, Path filePath, 
+        SupportedLanguage language, SupportedIDE ide, String superclassSource) {
+      this.serviceCalled = true;
+      this.lastCalledCwd = cwd;
+      this.lastCalledFilePath = filePath;
+      this.lastCalledLanguage = language;
+      this.lastCalledIDE = ide;
+      this.lastCalledSuperclassSource = superclassSource;
+      return this.responseToReturn;
+    }
+
+    public void setSuccessResponse(CreateJPARepositoryResponse response) {
+      this.responseToReturn = DataTransferObject.success(response);
+    }
+
+    public void setErrorResponse(String errorMessage) {
+      this.responseToReturn = DataTransferObject.error(errorMessage);
+    }
+
+    public void setNullResponse() {
+      this.responseToReturn = null;
+    }
+
+    public boolean wasServiceCalled() {
+      return this.serviceCalled;
+    }
+
+    public Path getLastCalledCwd() {
+      return this.lastCalledCwd;
+    }
+
+    public Path getLastCalledFilePath() {
+      return this.lastCalledFilePath;
+    }
+
+    public SupportedLanguage getLastCalledLanguage() {
+      return this.lastCalledLanguage;
+    }
+
+    public SupportedIDE getLastCalledIDE() {
+      return this.lastCalledIDE;
+    }
+
+    public String getLastCalledSuperclassSource() {
+      return this.lastCalledSuperclassSource;
+    }
+  }
+}

--- a/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
@@ -15,6 +15,7 @@ import io.github.syntaxpresso.core.service.java.language.ClassDeclarationService
 import io.github.syntaxpresso.core.service.java.language.FieldDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.FormalParameterService;
 import io.github.syntaxpresso.core.service.java.language.ImportDeclarationService;
+import io.github.syntaxpresso.core.service.java.language.InterfaceDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.LocalVariableDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.MethodDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.PackageDeclarationService;
@@ -61,12 +62,14 @@ class JavaLanguageServiceTest {
     LocalVariableDeclarationService localVariableDeclarationService =
         new LocalVariableDeclarationService();
     AnnotationService annotationService = new AnnotationService();
+    InterfaceDeclarationService interfaceDeclarationService = new InterfaceDeclarationService();
 
     this.javaLanguageService =
         new JavaLanguageService(
             this.pathHelper,
             variableNamingService,
             classDeclarationService,
+            interfaceDeclarationService,
             packageDeclarationService,
             importDeclarationService,
             localVariableDeclarationService,

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/AnnotationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/AnnotationServiceTest.java
@@ -290,6 +290,188 @@ class AnnotationServiceTest {
   }
 
   @Nested
+  @DisplayName("Interface Annotation Tests")
+  class InterfaceAnnotationTests {
+
+    @Test
+    @DisplayName("should find annotations on interfaces")
+    void shouldFindAnnotationsOnInterfaces() {
+      String code = "@Repository @Component public interface UserRepository {}";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+
+      List<TSNode> annotations = annotationService.getAllAnnotations(tsFile, interfaceNode);
+
+      assertEquals(2, annotations.size());
+    }
+
+    @Test
+    @DisplayName("should find specific annotation on interface by name")
+    void shouldFindSpecificAnnotationOnInterfaceByName() {
+      String code = "@Repository @Component public interface UserRepository {}";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+
+      Optional<TSNode> repositoryAnnotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "Repository");
+      Optional<TSNode> componentAnnotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "Component");
+      Optional<TSNode> nonExistentAnnotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "NonExistent");
+
+      assertTrue(repositoryAnnotation.isPresent());
+      assertTrue(componentAnnotation.isPresent());
+      assertFalse(nonExistentAnnotation.isPresent());
+    }
+
+    @Test
+    @DisplayName("should handle interface annotations with arguments")
+    void shouldHandleInterfaceAnnotationsWithArguments() {
+      String code = "@Component(value = \"userRepo\") public interface UserRepository {}";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+
+      Optional<TSNode> annotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "Component");
+
+      assertTrue(annotation.isPresent());
+      
+      Map<String, AnnotationArgument> arguments = annotationService.getAnnotationArguments(tsFile, annotation.get());
+      assertEquals(1, arguments.size());
+      assertTrue(arguments.containsKey("value"));
+      assertEquals("\"userRepo\"", arguments.get("value").getValue(tsFile));
+    }
+
+    @Test
+    @DisplayName("should get insertion position for interface annotations")
+    void shouldGetInsertionPositionForInterfaceAnnotations() {
+      String code = "@Repository public interface UserRepository {}";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+
+      AnnotationInsertionPoint beforeFirstPoint = annotationService.getAnnotationInsertionPosition(
+          tsFile, interfaceNode, AnnotationInsertionPosition.BEFORE_FIRST_ANNOTATION);
+      AnnotationInsertionPoint aboveScopePoint = annotationService.getAnnotationInsertionPosition(
+          tsFile, interfaceNode, AnnotationInsertionPosition.ABOVE_SCOPE_DECLARATION);
+
+      assertNotNull(beforeFirstPoint);
+      assertNotNull(aboveScopePoint);
+      assertEquals(AnnotationInsertionPosition.BEFORE_FIRST_ANNOTATION, beforeFirstPoint.getPosition());
+      assertEquals(AnnotationInsertionPosition.ABOVE_SCOPE_DECLARATION, aboveScopePoint.getPosition());
+    }
+
+    @Test
+    @DisplayName("should add annotation to interface above scope declaration")
+    void shouldAddAnnotationToInterfaceAboveScopeDeclaration() {
+      String code = "public interface SimpleRepository {}";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+      
+      AnnotationInsertionPoint insertionPoint = annotationService.getAnnotationInsertionPosition(
+          tsFile, interfaceNode, AnnotationInsertionPosition.ABOVE_SCOPE_DECLARATION);
+      
+      String originalCode = tsFile.getSourceCode();
+      annotationService.addAnnotation(tsFile, interfaceNode, insertionPoint, "@Repository");
+      String updatedCode = tsFile.getSourceCode();
+
+      assertTrue(updatedCode.contains("@Repository"));
+      assertTrue(updatedCode.contains("public interface SimpleRepository"));
+      assertTrue(updatedCode.length() > originalCode.length());
+    }
+
+    @Test
+    @DisplayName("should add annotation to interface before first annotation")
+    void shouldAddAnnotationToInterfaceBeforeFirstAnnotation() {
+      String code = "@Component public interface UserRepository {}";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+      
+      AnnotationInsertionPoint insertionPoint = annotationService.getAnnotationInsertionPosition(
+          tsFile, interfaceNode, AnnotationInsertionPosition.BEFORE_FIRST_ANNOTATION);
+      
+      String originalCode = tsFile.getSourceCode();
+      annotationService.addAnnotation(tsFile, interfaceNode, insertionPoint, "@Repository");
+      String updatedCode = tsFile.getSourceCode();
+
+      assertTrue(updatedCode.contains("@Repository"));
+      assertTrue(updatedCode.contains("@Component"));
+      assertTrue(updatedCode.length() > originalCode.length());
+      // @Repository should appear before @Component
+      int repositoryIndex = updatedCode.indexOf("@Repository");
+      int componentIndex = updatedCode.indexOf("@Component");
+      assertTrue(repositoryIndex < componentIndex);
+    }
+
+    @Test
+    @DisplayName("should handle complex interface with multiple annotations")
+    void shouldHandleComplexInterfaceWithMultipleAnnotations() {
+      String code = """
+          @Repository
+          @Component(value = "userRepo")
+          @Transactional(readOnly = true)
+          public interface UserRepository extends JpaRepository<User, Long> {
+              List<User> findByName(String name);
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+
+      List<TSNode> annotations = annotationService.getAllAnnotations(tsFile, interfaceNode);
+      Optional<TSNode> repositoryAnnotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "Repository");
+      Optional<TSNode> componentAnnotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "Component");
+      Optional<TSNode> transactionalAnnotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "Transactional");
+
+      assertEquals(3, annotations.size());
+      assertTrue(repositoryAnnotation.isPresent());
+      assertTrue(componentAnnotation.isPresent());
+      assertTrue(transactionalAnnotation.isPresent());
+
+      // Test getting argument from @Component annotation
+      Map<String, AnnotationArgument> componentArgs = annotationService.getAnnotationArguments(tsFile, componentAnnotation.get());
+      assertEquals(1, componentArgs.size());
+      assertEquals("\"userRepo\"", componentArgs.get("value").getValue(tsFile));
+
+      // Test getting argument from @Transactional annotation
+      Map<String, AnnotationArgument> transactionalArgs = annotationService.getAnnotationArguments(tsFile, transactionalAnnotation.get());
+      assertEquals(1, transactionalArgs.size());
+      assertEquals("true", transactionalArgs.get("readOnly").getValue(tsFile));
+    }
+
+    @Test
+    @DisplayName("should handle interface without existing annotations")
+    void shouldHandleInterfaceWithoutExistingAnnotations() {
+      String code = "public interface PlainInterface {}";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+
+      List<TSNode> annotations = annotationService.getAllAnnotations(tsFile, interfaceNode);
+      AnnotationInsertionPoint insertionPoint = annotationService.getAnnotationInsertionPosition(
+          tsFile, interfaceNode, AnnotationInsertionPosition.BEFORE_FIRST_ANNOTATION);
+
+      assertEquals(0, annotations.size());
+      assertNotNull(insertionPoint);
+      assertEquals(AnnotationInsertionPosition.BEFORE_FIRST_ANNOTATION, insertionPoint.getPosition());
+    }
+
+    @Test
+    @DisplayName("should handle nested interface annotations")
+    void shouldHandleNestedInterfaceAnnotations() {
+      String code = """
+          public class OuterClass {
+              @Component
+              public interface InnerInterface {
+                  void method();
+              }
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode interfaceNode = tsFile.query("(interface_declaration) @interface").execute().firstNode();
+
+      List<TSNode> annotations = annotationService.getAllAnnotations(tsFile, interfaceNode);
+      Optional<TSNode> componentAnnotation = annotationService.findAnnotationByName(tsFile, interfaceNode, "Component");
+
+      assertEquals(1, annotations.size());
+      assertTrue(componentAnnotation.isPresent());
+    }
+  }
+
+  @Nested
   @DisplayName("Error Handling Tests")
   class ErrorHandlingTests {
 
@@ -340,6 +522,27 @@ class AnnotationServiceTest {
       Map<String, AnnotationArgument> result = annotationService.getAnnotationArguments(null, null);
 
       assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("should reject unsupported node types for annotation operations")
+    void shouldRejectUnsupportedNodeTypesForAnnotationOperations() {
+      String code = "public interface TestInterface { void method(); }";
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, code);
+      TSNode identifierNode = tsFile.query("(identifier) @id").execute().firstNode();
+
+      // Test getAnnotationInsertionPosition with unsupported node type
+      AnnotationInsertionPoint insertionPoint = annotationService.getAnnotationInsertionPosition(
+          tsFile, identifierNode, AnnotationInsertionPosition.ABOVE_SCOPE_DECLARATION);
+
+      assertNull(insertionPoint);
+
+      // Test addAnnotation with unsupported node type
+      String originalCode = tsFile.getSourceCode();
+      annotationService.addAnnotation(tsFile, identifierNode, null, "@Test");
+      String finalCode = tsFile.getSourceCode();
+
+      assertEquals(originalCode, finalCode); // Should remain unchanged
     }
   }
 }

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/InterfaceDeclarationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/InterfaceDeclarationServiceTest.java
@@ -1,0 +1,436 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.syntaxpresso.core.common.TSFile;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.treesitter.TSNode;
+
+@DisplayName("InterfaceDeclarationService Tests")
+class InterfaceDeclarationServiceTest {
+  private InterfaceDeclarationService interfaceDeclarationService;
+
+  private static final String SIMPLE_INTERFACE_CODE =
+      """
+      public interface SimpleInterface {
+          void method();
+      }
+      """;
+
+  private static final String COMPLEX_INTERFACE_CODE =
+      """
+      package com.example;
+
+      import java.util.List;
+      import java.io.Serializable;
+
+      @Repository
+      public interface UserRepository extends JpaRepository<User, Long> {
+          List<User> findByName(String name);
+          Optional<User> findByEmail(String email);
+      }
+      """;
+
+  private static final String MULTIPLE_INTERFACES_CODE =
+      """
+      package com.example;
+
+      interface InternalInterface {
+          void internalMethod();
+      }
+
+      public interface PublicInterface {
+          void publicMethod();
+      }
+
+      interface AnotherInterface extends PublicInterface {
+          void anotherMethod();
+      }
+      """;
+
+  private static final String NO_PUBLIC_INTERFACE_CODE =
+      """
+      package com.example;
+
+      interface InternalInterface {
+          void method();
+      }
+
+      interface AnotherInternalInterface {
+          void anotherMethod();
+      }
+      """;
+
+  @BeforeEach
+  void setUp() {
+    this.interfaceDeclarationService = new InterfaceDeclarationService();
+  }
+
+  @Nested
+  @DisplayName("findInterfaceByName Tests")
+  class FindInterfaceByNameTests {
+
+    @Test
+    @DisplayName("Should find interface by exact name")
+    void shouldFindInterfaceByExactName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_INTERFACE_CODE);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "SimpleInterface");
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find complex interface by name")
+    void shouldFindComplexInterfaceByName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_INTERFACE_CODE);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "UserRepository");
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find specific interface from multiple interfaces")
+    void shouldFindSpecificInterfaceFromMultiple() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_INTERFACES_CODE);
+
+      Optional<TSNode> internalResult =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "InternalInterface");
+      Optional<TSNode> publicResult =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "PublicInterface");
+      Optional<TSNode> anotherResult =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "AnotherInterface");
+
+      assertTrue(internalResult.isPresent());
+      assertTrue(publicResult.isPresent());
+      assertTrue(anotherResult.isPresent());
+      assertEquals("interface_declaration", internalResult.get().getType());
+      assertEquals("interface_declaration", publicResult.get().getType());
+      assertEquals("interface_declaration", anotherResult.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when interface not found")
+    void shouldReturnEmptyWhenInterfaceNotFound() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_INTERFACE_CODE);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "NonExistentInterface");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(null, "SimpleInterface");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when interface name is null")
+    void shouldReturnEmptyWhenInterfaceNameIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_INTERFACE_CODE);
+      Optional<TSNode> result = interfaceDeclarationService.findInterfaceByName(tsFile, null);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when interface name is empty")
+    void shouldReturnEmptyWhenInterfaceNameIsEmpty() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_INTERFACE_CODE);
+      Optional<TSNode> result = interfaceDeclarationService.findInterfaceByName(tsFile, "");
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getPublicInterface Tests")
+  class GetPublicInterfaceTests {
+
+    @Test
+    @DisplayName("Should get public interface matching filename")
+    void shouldGetPublicInterfaceMatchingFilename(@TempDir Path tempDir) throws IOException {
+      Path interfaceFile = tempDir.resolve("SimpleInterface.java");
+      Files.writeString(interfaceFile, SIMPLE_INTERFACE_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, interfaceFile);
+
+      Optional<TSNode> result = interfaceDeclarationService.getPublicInterface(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should get public interface matching filename for complex interface")
+    void shouldGetPublicInterfaceMatchingFilenameForComplex(@TempDir Path tempDir)
+        throws IOException {
+      Path interfaceFile = tempDir.resolve("UserRepository.java");
+      Files.writeString(interfaceFile, COMPLEX_INTERFACE_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, interfaceFile);
+
+      Optional<TSNode> result = interfaceDeclarationService.getPublicInterface(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when filename doesn't match any interface")
+    void shouldReturnEmptyWhenFilenameDoesntMatchAnyInterface(@TempDir Path tempDir)
+        throws IOException {
+      Path interfaceFile = tempDir.resolve("WrongName.java");
+      Files.writeString(interfaceFile, MULTIPLE_INTERFACES_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, interfaceFile);
+
+      Optional<TSNode> result = interfaceDeclarationService.getPublicInterface(tsFile);
+
+      // Since filename is "WrongName" and no interface has that name, should return empty
+      // getPublicInterface only falls back to getFirstPublicInterface when NO filename is available
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when no public interface exists")
+    void shouldReturnEmptyWhenNoPublicInterfaceExists(@TempDir Path tempDir) throws IOException {
+      Path interfaceFile = tempDir.resolve("NoPublic.java");
+      Files.writeString(interfaceFile, NO_PUBLIC_INTERFACE_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, interfaceFile);
+
+      Optional<TSNode> result = interfaceDeclarationService.getPublicInterface(tsFile);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should fallback to first public interface when no filename available")
+    void shouldFallbackToFirstPublicInterfaceWhenNoFilenameAvailable() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_INTERFACES_CODE);
+
+      Optional<TSNode> result = interfaceDeclarationService.getPublicInterface(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result = interfaceDeclarationService.getPublicInterface(null);
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getInterfaceNameNode Tests")
+  class GetInterfaceNameNodeTests {
+
+    @Test
+    @DisplayName("Should get interface name node from simple interface")
+    void shouldGetInterfaceNameNodeFromSimpleInterface() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_INTERFACE_CODE);
+      Optional<TSNode> interfaceNode =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "SimpleInterface");
+
+      assertTrue(interfaceNode.isPresent());
+      Optional<TSNode> nameNode =
+          interfaceDeclarationService.getInterfaceNameNode(tsFile, interfaceNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("SimpleInterface", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get interface name node from complex interface")
+    void shouldGetInterfaceNameNodeFromComplexInterface() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_INTERFACE_CODE);
+      Optional<TSNode> interfaceNode =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "UserRepository");
+
+      assertTrue(interfaceNode.isPresent());
+      Optional<TSNode> nameNode =
+          interfaceDeclarationService.getInterfaceNameNode(tsFile, interfaceNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("UserRepository", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get interface name node from multiple interfaces")
+    void shouldGetInterfaceNameNodeFromMultipleInterfaces() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_INTERFACES_CODE);
+      Optional<TSNode> publicInterfaceNode =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "PublicInterface");
+
+      assertTrue(publicInterfaceNode.isPresent());
+      Optional<TSNode> nameNode =
+          interfaceDeclarationService.getInterfaceNameNode(tsFile, publicInterfaceNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("PublicInterface", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_INTERFACE_CODE);
+      Optional<TSNode> interfaceNode =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "SimpleInterface");
+
+      assertTrue(interfaceNode.isPresent());
+      Optional<TSNode> nameNode =
+          interfaceDeclarationService.getInterfaceNameNode(null, interfaceNode.get());
+
+      assertFalse(nameNode.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when node is not interface_declaration")
+    void shouldReturnEmptyWhenNodeIsNotInterfaceDeclaration() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_INTERFACE_CODE);
+      TSNode rootNode = tsFile.getTree().getRootNode();
+
+      Optional<TSNode> nameNode =
+          interfaceDeclarationService.getInterfaceNameNode(tsFile, rootNode);
+
+      assertFalse(nameNode.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases and Error Handling")
+  class EdgeCasesAndErrorHandlingTests {
+
+    @Test
+    @DisplayName("Should handle interface with generic parameters")
+    void shouldHandleInterfaceWithGenericParameters() {
+      String genericInterfaceCode =
+          """
+          public interface GenericInterface<T, U extends Serializable> {
+              T process(U input);
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, genericInterfaceCode);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "GenericInterface");
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle interface with multiple inheritance")
+    void shouldHandleInterfaceWithMultipleInheritance() {
+      String multipleInheritanceCode =
+          """
+          public interface MultipleInterface extends Interface1, Interface2, Interface3 {
+              void method();
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, multipleInheritanceCode);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "MultipleInterface");
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle interface with annotations")
+    void shouldHandleInterfaceWithAnnotations() {
+      String annotatedInterfaceCode =
+          """
+          @Repository
+          @Component
+          @CustomAnnotation(value = "test")
+          public interface AnnotatedInterface {
+              void method();
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotatedInterfaceCode);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "AnnotatedInterface");
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle nested interfaces")
+    void shouldHandleNestedInterfaces() {
+      String nestedInterfaceCode =
+          """
+          public class OuterClass {
+              public interface InnerInterface {
+                  void method();
+              }
+              
+              private interface PrivateInterface {
+                  void privateMethod();
+              }
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, nestedInterfaceCode);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "InnerInterface");
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle empty interface")
+    void shouldHandleEmptyInterface() {
+      String emptyInterfaceCode =
+          """
+          public interface EmptyInterface {
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, emptyInterfaceCode);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "EmptyInterface");
+
+      assertTrue(result.isPresent());
+      assertEquals("interface_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty for malformed interface")
+    void shouldReturnEmptyForMalformedInterface() {
+      String malformedCode =
+          """
+          public interface MalformedInterface
+          void method();
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, malformedCode);
+      Optional<TSNode> result =
+          interfaceDeclarationService.findInterfaceByName(tsFile, "MalformedInterface");
+
+      // Tree-sitter cannot parse this malformed interface correctly
+      assertFalse(result.isPresent());
+    }
+  }
+}

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/InterfaceDeclarationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/InterfaceDeclarationServiceTest.java
@@ -2,7 +2,6 @@ package io.github.syntaxpresso.core.service.java.language;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.syntaxpresso.core.common.TSFile;
@@ -386,7 +385,7 @@ class InterfaceDeclarationServiceTest {
               public interface InnerInterface {
                   void method();
               }
-              
+
               private interface PrivateInterface {
                   void privateMethod();
               }
@@ -434,3 +433,4 @@ class InterfaceDeclarationServiceTest {
     }
   }
 }
+


### PR DESCRIPTION
This pull request introduces support for generating JPA repositories in addition to JPA entities within the codebase. The main changes include adding a new command and service for creating JPA repositories, updating the command factory and core registration to handle the new functionality, and extending the file template system to support JPA repository code generation.

**JPA Repository Feature Additions:**

* Added a new `CreateJPARepositoryCommand` class, enabling command-line creation of JPA repositories, with support for an optional superclass source and a dedicated response DTO (`CreateJPARepositoryResponse`). [[1]](diffhunk://#diff-3d321077269d24cd4821f8302420e73b03999b6effd1388ebfe0748398123175L1-R54) [[2]](diffhunk://#diff-a0feabdfabd07f262f50c6531bfadb983034ff4a6e04f643c09456bdbd4409adR1-R26)
* Registered `CreateJPARepositoryCommand` in the `Core` class and updated the command factory to instantiate it with its corresponding service. [[1]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777L26-R27) [[2]](diffhunk://#diff-13b624bcdb527541bb3e838a21909a3d6f03ec08bad3788c5d634ccfed3275f9L38-R41)
* Implemented and injected `CreateJPARepositoryCommandService` into the command factory and core initialization logic. [[1]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R104-R113) [[2]](diffhunk://#diff-13b624bcdb527541bb3e838a21909a3d6f03ec08bad3788c5d634ccfed3275f9R16)

**Template and Service Enhancements:**

* Extended the `JavaFileTemplate` enum to include a `JPA_REPOSITORY` template and added a new method for generating repository source code with entity and ID types. [[1]](diffhunk://#diff-490f53a956cb24096ee11c7ce0fe319cdfdf4d4ec6a985f126530c72ab6cc4f3L8-R9) [[2]](diffhunk://#diff-490f53a956cb24096ee11c7ce0fe319cdfdf4d4ec6a985f126530c72ab6cc4f3R19-R25)
* Updated `JavaLanguageService` and related initialization to include `InterfaceDeclarationService`, supporting interface-based code generation required for repositories. [[1]](diffhunk://#diff-4e06ae448ab5b48fc994662360f4f72dc9947e24630a64069b15619cb9f5d635R10) [[2]](diffhunk://#diff-4e06ae448ab5b48fc994662360f4f72dc9947e24630a64069b15619cb9f5d635R28)

These changes collectively enable the automated creation of JPA repository interfaces, complementing the existing JPA entity generation workflow.