### PR TITLE
Update JavaFileTemplate

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/command/extra/JavaFileTemplate.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/extra/JavaFileTemplate.java
@@ -1,11 +1,11 @@
 package io.github.syntaxpresso.core.command.extra;
 
 public enum JavaFileTemplate {
-  CLASS("package %s;%n%npublic class %s {\n\n}"),
-  INTERFACE("package %s;%n%npublic interface %s {\n\n}"),
-  ENUM("package %s;%n%npublic enum %s {\n\n}"),
-  RECORD("package %s;%n%npublic record %s(\n\n) {\n\n}"),
-  ANNOTATION("package %s;%n%npublic @interface %s {\n\n}");
+  CLASS("package %s;%n%npublic class %s {}"),
+  INTERFACE("package %s;%n%npublic interface %s {}"),
+  ENUM("package %s;%n%npublic enum %s {}"),
+  RECORD("package %s;%n%npublic record %s() {}"),
+  ANNOTATION("package %s;%n%npublic @interface %s {}");
   private final String template;
 
   JavaFileTemplate(String template) {


### PR DESCRIPTION
This pull request simplifies the Java file templates in the `JavaFileTemplate` enum by removing unnecessary whitespace and empty lines from the generated code structures. The templates now produce more concise and minimal class, interface, enum, record, and annotation declarations.

Template simplification:

* Updated all templates in the `JavaFileTemplate` enum (in `JavaFileTemplate.java`) to use single-line, minimal syntax for class, interface, enum, record, and annotation declarations, removing extra newlines and empty blocks.