### PR TITLE
Create GetAllFilesCommand

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/Core.java
+++ b/src/main/java/io/github/syntaxpresso/core/Core.java
@@ -22,7 +22,8 @@ import picocli.CommandLine.Command;
       CreateNewFileCommand.class,
       GetCursorPositionInfoCommand.class,
       CreateNewJPAEntityCommand.class,
-      CreateJPARepositoryCommand.class
+      CreateJPARepositoryCommand.class,
+      GetAllFilesCommand.class
     })
 public class Core {
 
@@ -76,6 +77,9 @@ public class Core {
     ImportDeclarationService importDeclarationService = new ImportDeclarationService();
     LocalVariableDeclarationService localVariableDeclarationService =
         new LocalVariableDeclarationService();
+    EnumDeclarationService enumDeclarationService = new EnumDeclarationService();
+    RecordDeclarationService recordDeclarationService = new RecordDeclarationService();
+    AnnotationDeclarationService annotationDeclarationService = new AnnotationDeclarationService();
     AnnotationService annotationService = new AnnotationService();
     JavaLanguageService javaLanguageService =
         new JavaLanguageService(
@@ -83,6 +87,9 @@ public class Core {
             variableNamingService,
             classDeclarationService,
             interfaceDeclarationService,
+            enumDeclarationService,
+            recordDeclarationService,
+            annotationDeclarationService,
             packageDeclarationService,
             importDeclarationService,
             localVariableDeclarationService,
@@ -99,12 +106,15 @@ public class Core {
         new CreateNewJPAEntityCommandService(javaLanguageService, createNewFileCommandService);
     CreateJPARepositoryCommandService createJPARepositoryCommandService =
         new CreateJPARepositoryCommandService(javaLanguageService, createNewFileCommandService);
+    GetAllFilesCommandService getAllFilesCommandService =
+        new GetAllFilesCommandService(javaLanguageService);
     return new CommandFactory(
         renameCommandService,
         getMainClassCommandService,
         createNewFileCommandService,
         getCursorPositionInfoCommandService,
         createNewJPAEntityCommandService,
-        createJPARepositoryCommandService);
+        createJPARepositoryCommandService,
+        getAllFilesCommandService);
   }
 }

--- a/src/main/java/io/github/syntaxpresso/core/command/GetAllFilesCommand.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/GetAllFilesCommand.java
@@ -1,0 +1,53 @@
+package io.github.syntaxpresso.core.command;
+
+import io.github.syntaxpresso.core.command.dto.GetAllFilesResponse;
+import io.github.syntaxpresso.core.command.extra.JavaFileTemplate;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.command.GetAllFilesCommandService;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import lombok.RequiredArgsConstructor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@RequiredArgsConstructor
+@Command(
+    name = "get-all-files",
+    description = "Get a list of all files in the current working directory by it's type.")
+public class GetAllFilesCommand implements Callable<DataTransferObject<GetAllFilesResponse>> {
+  private final GetAllFilesCommandService getAllFilesCommandService;
+
+  @Option(
+      names = {"--cwd"},
+      description = "The current working directory.",
+      required = true)
+  private Path cwd;
+
+  @Option(
+      names = {"--file-type"},
+      description = "The type of the files (CLASS, INTERFACE, ENUM, RECORD, ANNOTATION).",
+      required = true)
+  private JavaFileTemplate fileType;
+
+  @Option(
+      names = "--language",
+      description = "The language related to the command execution.",
+      required = false)
+  private SupportedLanguage language = SupportedLanguage.JAVA;
+
+  @Option(
+      names = "--ide",
+      description = "The IDE the command is being called from.",
+      required = false)
+  private SupportedIDE ide = SupportedIDE.NONE;
+
+  @Override
+  public DataTransferObject<GetAllFilesResponse> call() {
+    if (this.language != null && this.language.equals(SupportedLanguage.JAVA)) {
+      return this.getAllFilesCommandService.run(this.cwd, this.fileType);
+    }
+    return DataTransferObject.error("Language not supported.");
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/command/dto/FileResponse.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/dto/FileResponse.java
@@ -1,0 +1,14 @@
+package io.github.syntaxpresso.core.command.dto;
+
+import java.io.Serializable;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileResponse implements Serializable {
+  private String type;
+  private String packagePath;
+  private String filePath;
+}

--- a/src/main/java/io/github/syntaxpresso/core/command/dto/GetAllFilesResponse.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/dto/GetAllFilesResponse.java
@@ -1,0 +1,15 @@
+package io.github.syntaxpresso.core.command.dto;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetAllFilesResponse implements Serializable {
+  @Builder.Default
+  private List<FileResponse> response = new ArrayList<>();
+}

--- a/src/main/java/io/github/syntaxpresso/core/common/CommandFactory.java
+++ b/src/main/java/io/github/syntaxpresso/core/common/CommandFactory.java
@@ -13,6 +13,7 @@ public class CommandFactory implements IFactory {
   private final GetCursorPositionInfoCommandService getCursorPositionInfoCommandService;
   private final CreateNewJPAEntityCommandService createNewJPAEntityCommandService;
   private final CreateJPARepositoryCommandService createJPARepositoryCommandService;
+  private final GetAllFilesCommandService getAllFilesCommandService;
 
   @Override
   @SuppressWarnings("unchecked")
@@ -35,9 +36,9 @@ public class CommandFactory implements IFactory {
     if (cls == CreateJPARepositoryCommand.class) {
       return (K) new CreateJPARepositoryCommand(createJPARepositoryCommandService);
     }
-    // if (cls == GetJPAEntityInfoCommand.class) {
-    //   return (K) new GetJPAEntityInfoCommand(javaCommandService);
-    // }
+    if (cls == GetAllFilesCommand.class) {
+      return (K) new GetAllFilesCommand(getAllFilesCommandService);
+    }
     return cls.getDeclaredConstructor().newInstance();
   }
 }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/JavaLanguageService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/JavaLanguageService.java
@@ -4,12 +4,15 @@ import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.common.extra.SupportedIDE;
 import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.extra.JavaIdentifierType;
+import io.github.syntaxpresso.core.service.java.language.AnnotationDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.AnnotationService;
 import io.github.syntaxpresso.core.service.java.language.ClassDeclarationService;
+import io.github.syntaxpresso.core.service.java.language.EnumDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.ImportDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.InterfaceDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.LocalVariableDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.PackageDeclarationService;
+import io.github.syntaxpresso.core.service.java.language.RecordDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.VariableNamingService;
 import io.github.syntaxpresso.core.util.PathHelper;
 import java.nio.file.Files;
@@ -26,6 +29,9 @@ public class JavaLanguageService {
   private final VariableNamingService variableNamingService;
   private final ClassDeclarationService classDeclarationService;
   private final InterfaceDeclarationService interfaceDeclarationService;
+  private final EnumDeclarationService enumDeclarationService;
+  private final RecordDeclarationService recordDeclarationService;
+  private final AnnotationDeclarationService annotationDeclarationService;
   private final PackageDeclarationService packageDeclarationService;
   private final ImportDeclarationService importDeclarationService;
   private final LocalVariableDeclarationService localVariableDeclarationService;
@@ -75,6 +81,14 @@ public class JavaLanguageService {
     String parentType = parent.getType();
     switch (parentType) {
       case "class_declaration":
+        return JavaIdentifierType.CLASS_NAME;
+      case "interface_declaration":
+        return JavaIdentifierType.CLASS_NAME;
+      case "enum_declaration":
+        return JavaIdentifierType.CLASS_NAME;
+      case "record_declaration":
+        return JavaIdentifierType.CLASS_NAME;
+      case "annotation_type_declaration":
         return JavaIdentifierType.CLASS_NAME;
       case "method_declaration":
         return JavaIdentifierType.METHOD_NAME;

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/GetAllFilesCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/GetAllFilesCommandService.java
@@ -1,0 +1,87 @@
+package io.github.syntaxpresso.core.service.java.command;
+
+import io.github.syntaxpresso.core.command.dto.FileResponse;
+import io.github.syntaxpresso.core.command.dto.GetAllFilesResponse;
+import io.github.syntaxpresso.core.command.extra.JavaFileTemplate;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.TSFile;
+import io.github.syntaxpresso.core.service.java.JavaLanguageService;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.treesitter.TSNode;
+
+@Getter
+@RequiredArgsConstructor
+public class GetAllFilesCommandService {
+  private final JavaLanguageService javaLanguageService;
+
+  private Optional<TSNode> getPublicNodeByFileType(TSFile tsFile, JavaFileTemplate fileType) {
+    if (fileType.equals(JavaFileTemplate.ENUM)) {
+      return this.javaLanguageService.getEnumDeclarationService().getPublicEnum(tsFile);
+    } else if (fileType.equals(JavaFileTemplate.CLASS)) {
+      return this.javaLanguageService.getClassDeclarationService().getPublicClass(tsFile);
+    } else if (fileType.equals(JavaFileTemplate.ANNOTATION)) {
+      return this.javaLanguageService.getAnnotationDeclarationService().getPublicAnnotation(tsFile);
+    } else if (fileType.equals(JavaFileTemplate.RECORD)) {
+      return this.javaLanguageService.getRecordDeclarationService().getPublicRecord(tsFile);
+    } else if (fileType.equals(JavaFileTemplate.INTERFACE)) {
+      return this.javaLanguageService.getInterfaceDeclarationService().getPublicInterface(tsFile);
+    }
+    return Optional.empty();
+  }
+
+  private Optional<String> extractPackageScope(TSFile tsFile) {
+    Optional<TSNode> packageDeclarationNode =
+        this.javaLanguageService.getPackageDeclarationService().getPackageDeclarationNode(tsFile);
+    if (packageDeclarationNode.isEmpty()) {
+      return Optional.empty();
+    }
+    Optional<TSNode> packageScopeNode =
+        this.javaLanguageService
+            .getPackageDeclarationService()
+            .getPackageClassScopeNode(tsFile, packageDeclarationNode.get());
+    if (packageScopeNode.isPresent()) {
+      String packageScope = tsFile.getTextFromNode(packageScopeNode.get());
+      return Optional.of(packageScope);
+    }
+    return Optional.empty();
+  }
+
+  private Optional<FileResponse> createFileResponse(TSFile tsFile) {
+    Optional<String> fileName = tsFile.getFileNameWithoutExtension();
+    if (fileName.isEmpty()) {
+      return Optional.empty();
+    }
+    FileResponse fileResponse = new FileResponse();
+    fileResponse.setType(fileName.get());
+    String filePath = tsFile.getFile().getAbsolutePath();
+    fileResponse.setFilePath(filePath);
+    return Optional.of(fileResponse);
+  }
+
+  public DataTransferObject<GetAllFilesResponse> run(Path cwd, JavaFileTemplate fileType) {
+    GetAllFilesResponse response = new GetAllFilesResponse();
+    List<TSFile> allJavaFiles = this.javaLanguageService.getAllJavaFilesFromCwd(cwd);
+    for (TSFile tsFile : allJavaFiles) {
+      Optional<FileResponse> fileResponseOpt = createFileResponse(tsFile);
+      if (fileResponseOpt.isEmpty()) {
+        continue;
+      }
+      FileResponse fileResponse = fileResponseOpt.get();
+      Optional<TSNode> publicNode = getPublicNodeByFileType(tsFile, fileType);
+      if (publicNode.isEmpty()) {
+        continue;
+      }
+      Optional<String> packageScope = extractPackageScope(tsFile);
+      if (packageScope.isEmpty()) {
+        continue;
+      }
+      fileResponse.setPackagePath(packageScope.get());
+      response.getResponse().add(fileResponse);
+    }
+    return DataTransferObject.success(response);
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/AnnotationDeclarationService.java
@@ -1,0 +1,156 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import com.google.common.base.Strings;
+import io.github.syntaxpresso.core.common.TSFile;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.treesitter.TSNode;
+
+@Getter
+@RequiredArgsConstructor
+public class AnnotationDeclarationService {
+
+  /**
+   * Finds an annotation declaration node by its name.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> annotationNode = service.findAnnotationByName(tsFile, "MyAnnotation");
+   * if (annotationNode.isPresent()) {
+   *   String annotationDecl = tsFile.getTextFromNode(annotationNode.get());
+   *   // annotationDecl = "public @interface MyAnnotation { String value(); }"
+   * }
+   * </pre>
+   *
+   * @param tsFile {@link TSFile} containing the source code
+   * @param annotationName Name of the annotation to search for
+   * @return {@link Optional} containing the annotation declaration node, or empty if not found,
+   *     file/tree is null, or annotationName is empty
+   */
+  public Optional<TSNode> findAnnotationByName(TSFile tsFile, String annotationName) {
+    if (tsFile == null || tsFile.getTree() == null || Strings.isNullOrEmpty(annotationName)) {
+      return Optional.empty();
+    }
+    String queryString =
+        String.format(
+            """
+            (annotation_type_declaration
+              name: (identifier) @annotationName
+            (#eq? @annotationName "%s")) @annotationDeclaration
+            """,
+            annotationName);
+    return tsFile
+        .query(queryString)
+        .returning("annotationDeclaration")
+        .execute()
+        .firstNodeOptional();
+  }
+
+  /**
+   * Gets the public annotation of a file, defined as the public annotation whose name matches the
+   * file name. If the file name is not available, falls back to finding the first public annotation.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * // For a file named "MyAnnotation.java"
+   * Optional<TSNode> publicAnnotation = service.getPublicAnnotation(tsFile);
+   * if (publicAnnotation.isPresent()) {
+   *   String annotationDecl = tsFile.getTextFromNode(publicAnnotation.get());
+   *   // annotationDecl = "public @interface MyAnnotation ..."
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} to analyze.
+   * @return An {@link Optional} containing the public annotation declaration node, or empty if not
+   *     found, file/tree is null, or file name is missing.
+   */
+  public Optional<TSNode> getPublicAnnotation(TSFile tsFile) {
+    if (tsFile == null || tsFile.getTree() == null) {
+      return Optional.empty();
+    }
+    Optional<String> fileName = tsFile.getFileNameWithoutExtension();
+    if (fileName.isEmpty()) {
+      return this.getFirstPublicAnnotation(tsFile);
+    }
+    return this.findAnnotationByName(tsFile, fileName.get());
+  }
+
+  /**
+   * Gets the name identifier node from an annotation declaration.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> nameNode = service.getAnnotationNameNode(tsFile, annotationNode);
+   * if (nameNode.isPresent()) {
+   *   String annotationName = tsFile.getTextFromNode(nameNode.get());
+   *   // annotationName = "MyAnnotation"
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} containing the annotation declaration
+   * @param annotationDeclarationNode The annotation declaration node to analyze
+   * @return Optional containing the annotation name identifier node if found, empty otherwise
+   */
+  public Optional<TSNode> getAnnotationNameNode(TSFile tsFile, TSNode annotationDeclarationNode) {
+    if (tsFile == null
+        || tsFile.getTree() == null
+        || !annotationDeclarationNode.getType().equals("annotation_type_declaration")) {
+      return Optional.empty();
+    }
+    String queryString =
+        """
+        (annotation_type_declaration
+          name: (identifier) @annotationName
+        ) @annotationDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile
+            .query(queryString)
+            .within(annotationDeclarationNode)
+            .returningAllCaptures()
+            .execute()
+            .captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode nameNode = result.get("annotationName");
+      if (nameNode != null) {
+        return Optional.of(nameNode);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Gets the first public annotation declaration found in the file. This is useful when the file
+   * path is not available but you need to find the main annotation.
+   *
+   * @param tsFile The {@link TSFile} to analyze
+   * @return Optional containing the first public annotation declaration node, empty if none found
+   */
+  private Optional<TSNode> getFirstPublicAnnotation(TSFile tsFile) {
+    String queryString =
+        """
+        (annotation_type_declaration
+          (modifiers) @modifiers
+          name: (identifier) @annotationName
+        ) @annotationDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile.query(queryString).returningAllCaptures().execute().captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode modifiers = result.get("modifiers");
+      if (modifiers != null) {
+        String modifierText = tsFile.getTextFromNode(modifiers);
+        if (modifierText.contains("public")) {
+          return Optional.of(result.get("annotationDeclaration"));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/EnumDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/EnumDeclarationService.java
@@ -1,0 +1,157 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import com.google.common.base.Strings;
+import io.github.syntaxpresso.core.common.TSFile;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.treesitter.TSNode;
+
+@Getter
+@RequiredArgsConstructor
+public class EnumDeclarationService {
+
+  /**
+   * Finds an enum declaration node by its name.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> enumNode = service.findEnumByName(tsFile, "Color");
+   * if (enumNode.isPresent()) {
+   *   String enumDecl = tsFile.getTextFromNode(enumNode.get());
+   *   // enumDecl = "public enum Color { RED, GREEN, BLUE }"
+   * }
+   * </pre>
+   *
+   * @param tsFile {@link TSFile} containing the source code
+   * @param enumName Name of the enum to search for
+   * @return {@link Optional} containing the enum declaration node, or empty if not found,
+   *     file/tree is null, or enumName is empty
+   */
+  public Optional<TSNode> findEnumByName(TSFile tsFile, String enumName) {
+    if (tsFile == null || tsFile.getTree() == null || Strings.isNullOrEmpty(enumName)) {
+      return Optional.empty();
+    }
+    String queryString =
+        String.format(
+            """
+            (enum_declaration
+              name: (identifier) @enumName
+            (#eq? @enumName "%s")) @enumDeclaration
+            """,
+            enumName);
+    return tsFile
+        .query(queryString)
+        .returning("enumDeclaration")
+        .execute()
+        .firstNodeOptional();
+  }
+
+  /**
+   * Gets the public enum of a file, defined as the public enum whose name matches the
+   * file name. If the file name is not available, falls back to finding the first public enum.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * // For a file named "Color.java"
+   * Optional<TSNode> publicEnum = service.getPublicEnum(tsFile);
+   * if (publicEnum.isPresent()) {
+   *   String enumDecl = tsFile.getTextFromNode(publicEnum.get());
+   *   // enumDecl = "public enum Color ..."
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} to analyze.
+   * @return An {@link Optional} containing the public enum declaration node, or empty if not
+   *     found, file/tree is null, or file name is missing.
+   */
+  public Optional<TSNode> getPublicEnum(TSFile tsFile) {
+    if (tsFile == null || tsFile.getTree() == null) {
+      return Optional.empty();
+    }
+    Optional<String> fileName = tsFile.getFileNameWithoutExtension();
+    if (fileName.isEmpty()) {
+      return this.getFirstPublicEnum(tsFile);
+    }
+    return this.findEnumByName(tsFile, fileName.get());
+  }
+
+  /**
+   * Gets the name identifier node from an enum declaration.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> nameNode = service.getEnumNameNode(tsFile, enumNode);
+   * if (nameNode.isPresent()) {
+   *   String enumName = tsFile.getTextFromNode(nameNode.get());
+   *   // enumName = "Color"
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} containing the enum declaration
+   * @param enumDeclarationNode The enum declaration node to analyze
+   * @return Optional containing the enum name identifier node if found, empty otherwise
+   */
+  public Optional<TSNode> getEnumNameNode(TSFile tsFile, TSNode enumDeclarationNode) {
+    if (tsFile == null
+        || tsFile.getTree() == null
+        || !enumDeclarationNode.getType().equals("enum_declaration")) {
+      return Optional.empty();
+    }
+    String queryString =
+        """
+        (enum_declaration
+          name: (identifier) @enumName
+        ) @enumDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile
+            .query(queryString)
+            .within(enumDeclarationNode)
+            .returningAllCaptures()
+            .execute()
+            .captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode nameNode = result.get("enumName");
+      if (nameNode != null) {
+        return Optional.of(nameNode);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Gets the first public enum declaration found in the file. This is useful when the file
+   * path is not available but you need to find the main enum.
+   *
+   * @param tsFile The {@link TSFile} to analyze
+   * @return Optional containing the first public enum declaration node, empty if none found
+   */
+  private Optional<TSNode> getFirstPublicEnum(TSFile tsFile) {
+    String queryString =
+        """
+        (enum_declaration
+          (modifiers) @modifiers
+          name: (identifier) @enumName
+        ) @enumDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile.query(queryString).returningAllCaptures().execute().captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode modifiers = result.get("modifiers");
+      if (modifiers != null) {
+        String modifierText = tsFile.getTextFromNode(modifiers);
+        if (modifierText.contains("public")) {
+          return Optional.of(result.get("enumDeclaration"));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+}
+

--- a/src/main/java/io/github/syntaxpresso/core/service/java/language/RecordDeclarationService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/language/RecordDeclarationService.java
@@ -1,0 +1,156 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import com.google.common.base.Strings;
+import io.github.syntaxpresso.core.common.TSFile;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.treesitter.TSNode;
+
+@Getter
+@RequiredArgsConstructor
+public class RecordDeclarationService {
+
+  /**
+   * Finds a record declaration node by its name.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> recordNode = service.findRecordByName(tsFile, "Person");
+   * if (recordNode.isPresent()) {
+   *   String recordDecl = tsFile.getTextFromNode(recordNode.get());
+   *   // recordDecl = "public record Person(String name, int age) {}"
+   * }
+   * </pre>
+   *
+   * @param tsFile {@link TSFile} containing the source code
+   * @param recordName Name of the record to search for
+   * @return {@link Optional} containing the record declaration node, or empty if not found,
+   *     file/tree is null, or recordName is empty
+   */
+  public Optional<TSNode> findRecordByName(TSFile tsFile, String recordName) {
+    if (tsFile == null || tsFile.getTree() == null || Strings.isNullOrEmpty(recordName)) {
+      return Optional.empty();
+    }
+    String queryString =
+        String.format(
+            """
+            (record_declaration
+              name: (identifier) @recordName
+            (#eq? @recordName "%s")) @recordDeclaration
+            """,
+            recordName);
+    return tsFile
+        .query(queryString)
+        .returning("recordDeclaration")
+        .execute()
+        .firstNodeOptional();
+  }
+
+  /**
+   * Gets the public record of a file, defined as the public record whose name matches the
+   * file name. If the file name is not available, falls back to finding the first public record.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * // For a file named "Person.java"
+   * Optional<TSNode> publicRecord = service.getPublicRecord(tsFile);
+   * if (publicRecord.isPresent()) {
+   *   String recordDecl = tsFile.getTextFromNode(publicRecord.get());
+   *   // recordDecl = "public record Person ..."
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} to analyze.
+   * @return An {@link Optional} containing the public record declaration node, or empty if not
+   *     found, file/tree is null, or file name is missing.
+   */
+  public Optional<TSNode> getPublicRecord(TSFile tsFile) {
+    if (tsFile == null || tsFile.getTree() == null) {
+      return Optional.empty();
+    }
+    Optional<String> fileName = tsFile.getFileNameWithoutExtension();
+    if (fileName.isEmpty()) {
+      return this.getFirstPublicRecord(tsFile);
+    }
+    return this.findRecordByName(tsFile, fileName.get());
+  }
+
+  /**
+   * Gets the name identifier node from a record declaration.
+   *
+   * <p>Usage example:
+   *
+   * <pre>
+   * Optional<TSNode> nameNode = service.getRecordNameNode(tsFile, recordNode);
+   * if (nameNode.isPresent()) {
+   *   String recordName = tsFile.getTextFromNode(nameNode.get());
+   *   // recordName = "Person"
+   * }
+   * </pre>
+   *
+   * @param tsFile The {@link TSFile} containing the record declaration
+   * @param recordDeclarationNode The record declaration node to analyze
+   * @return Optional containing the record name identifier node if found, empty otherwise
+   */
+  public Optional<TSNode> getRecordNameNode(TSFile tsFile, TSNode recordDeclarationNode) {
+    if (tsFile == null
+        || tsFile.getTree() == null
+        || !recordDeclarationNode.getType().equals("record_declaration")) {
+      return Optional.empty();
+    }
+    String queryString =
+        """
+        (record_declaration
+          name: (identifier) @recordName
+        ) @recordDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile
+            .query(queryString)
+            .within(recordDeclarationNode)
+            .returningAllCaptures()
+            .execute()
+            .captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode nameNode = result.get("recordName");
+      if (nameNode != null) {
+        return Optional.of(nameNode);
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Gets the first public record declaration found in the file. This is useful when the file
+   * path is not available but you need to find the main record.
+   *
+   * @param tsFile The {@link TSFile} to analyze
+   * @return Optional containing the first public record declaration node, empty if none found
+   */
+  private Optional<TSNode> getFirstPublicRecord(TSFile tsFile) {
+    String queryString =
+        """
+        (record_declaration
+          (modifiers) @modifiers
+          name: (identifier) @recordName
+        ) @recordDeclaration
+        """;
+    List<Map<String, TSNode>> results =
+        tsFile.query(queryString).returningAllCaptures().execute().captures();
+    for (Map<String, TSNode> result : results) {
+      TSNode modifiers = result.get("modifiers");
+      if (modifiers != null) {
+        String modifierText = tsFile.getTextFromNode(modifiers);
+        if (modifierText.contains("public")) {
+          return Optional.of(result.get("recordDeclaration"));
+        }
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/resources/META-INF/native-image/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/reachability-metadata.json
@@ -150,6 +150,66 @@
       ]
     },
     {
+      "type": "io.github.syntaxpresso.core.command.dto.GetAllFilesResponse",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": ["java.util.List"]
+        }
+      ]
+    },
+    {
+      "type": "io.github.syntaxpresso.core.command.dto.FileResponse",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": ["java.lang.String", "java.lang.String", "java.lang.String"]
+        }
+      ]
+    },
+    {
+      "type": "io.github.syntaxpresso.core.command.dto.CreateNewJPAEntityResponse",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": ["java.lang.String"]
+        }
+      ]
+    },
+    {
+      "type": "io.github.syntaxpresso.core.command.dto.GetJPAEntityInfoResponse",
+      "allDeclaredFields": true,
+      "allDeclaredMethods": true,
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "<init>",
+          "parameterTypes": ["java.lang.Boolean", "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String", "java.lang.String", "java.util.List"]
+        }
+      ]
+    },
+    {
       "type": "io.github.syntaxpresso.core.service.extra.JavaIdentifierType",
       "allDeclaredFields": true,
       "allDeclaredMethods": true

--- a/src/test/java/io/github/syntaxpresso/core/command/CreateNewJPAEntityCommandTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/command/CreateNewJPAEntityCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.github.syntaxpresso.core.command.dto.CreateNewJPAEntityResponse;
 import io.github.syntaxpresso.core.common.DataTransferObject;
 import io.github.syntaxpresso.core.service.java.command.CreateNewJPAEntityCommandService;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
@@ -17,8 +16,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Comprehensive tests for CreateNewJPAEntityCommand.
- * 
- * Example usage:
+ *
+ * <p>Example usage:
+ *
  * <pre>
  * CreateNewJPAEntityCommand command = new CreateNewJPAEntityCommand(service);
  * // Set command options: --cwd /path/to/project --package-name com.example --file-name User.java
@@ -50,7 +50,8 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should have correct picocli annotations")
     void shouldHaveCorrectPicocliAnnotations() {
       // Given & When
-      var commandAnnotation = CreateNewJPAEntityCommand.class.getAnnotation(picocli.CommandLine.Command.class);
+      var commandAnnotation =
+          CreateNewJPAEntityCommand.class.getAnnotation(picocli.CommandLine.Command.class);
 
       // Then
       assertNotNull(commandAnnotation);
@@ -63,28 +64,28 @@ class CreateNewJPAEntityCommandTest {
     void shouldReturnDataTransferObjectWithCorrectGenericType() {
       // Given & When
       assertTrue(createNewJPAEntityCommand instanceof Callable);
-      
+
       // Then - verify return type through successful call
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/User.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/User.java").build());
       setupCreateNewJPAEntityCommand(tempDir, "com.example", "User.java");
 
       // When
-      assertDoesNotThrow(() -> {
-        DataTransferObject<CreateNewJPAEntityResponse> result = createNewJPAEntityCommand.call();
-        assertNotNull(result);
-        assertTrue(result.getData() instanceof CreateNewJPAEntityResponse);
-      });
+      assertDoesNotThrow(
+          () -> {
+            DataTransferObject<CreateNewJPAEntityResponse> result =
+                createNewJPAEntityCommand.call();
+            assertNotNull(result);
+            assertTrue(result.getData() instanceof CreateNewJPAEntityResponse);
+          });
     }
 
     @Test
     @DisplayName("Should handle all required options")
     void shouldHandleAllRequiredOptions() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/Entity.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/Entity.java").build());
 
       // When
       setupCreateNewJPAEntityCommand(tempDir, "com.test.package", "TestEntity.java");
@@ -108,9 +109,10 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should successfully create new JPA entity")
     void shouldSuccessfullyCreateNewJPAEntity() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/src/main/java/com/example/User.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder()
+              .filePath("/test/src/main/java/com/example/User.java")
+              .build());
 
       setupCreateNewJPAEntityCommand(tempDir, "com.example", "User.java");
 
@@ -128,9 +130,8 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should handle different entity names with proper table naming")
     void shouldHandleDifferentEntityNamesWithProperTableNaming() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/OrderItem.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/OrderItem.java").build());
 
       setupCreateNewJPAEntityCommand(tempDir, "com.example.model", "OrderItem.java");
 
@@ -216,9 +217,8 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should handle different package name formats")
     void shouldHandleDifferentPackageNameFormats() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/Entity.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/Entity.java").build());
 
       setupCreateNewJPAEntityCommand(tempDir, "com.company.project.model.entity", "Entity.java");
 
@@ -239,9 +239,8 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should handle simple package names")
     void shouldHandleSimplePackageNames() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/User.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/User.java").build());
 
       setupCreateNewJPAEntityCommand(tempDir, "model", "User.java");
 
@@ -257,9 +256,8 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should handle complex class names")
     void shouldHandleComplexClassNames() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/UserOrderHistory.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/UserOrderHistory.java").build());
 
       setupCreateNewJPAEntityCommand(tempDir, "com.example.model", "UserOrderHistory.java");
 
@@ -275,9 +273,8 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should handle single character class names")
     void shouldHandleSingleCharacterClassNames() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/X.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/X.java").build());
 
       setupCreateNewJPAEntityCommand(tempDir, "com.example", "X.java");
 
@@ -330,10 +327,11 @@ class CreateNewJPAEntityCommandTest {
       // Given
       Path complexDir = tempDir.resolve("very").resolve("deep").resolve("nested").resolve("path");
       Files.createDirectories(complexDir);
-      
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath(complexDir.resolve("ComplexEntity.java").toString())
-          .build());
+
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder()
+              .filePath(complexDir.resolve("ComplexEntity.java").toString())
+              .build());
 
       setupCreateNewJPAEntityCommand(complexDir, "com.example.deep.nested", "ComplexEntity.java");
 
@@ -380,9 +378,8 @@ class CreateNewJPAEntityCommandTest {
     @DisplayName("Should handle empty package names")
     void shouldHandleEmptyPackageNames() throws Exception {
       // Given
-      testService.setSuccessResponse(CreateNewJPAEntityResponse.builder()
-          .filePath("/test/User.java")
-          .build());
+      testService.setSuccessResponse(
+          CreateNewJPAEntityResponse.builder().filePath("/test/User.java").build());
 
       setupCreateNewJPAEntityCommand(tempDir, "", "User.java");
 
@@ -395,18 +392,14 @@ class CreateNewJPAEntityCommandTest {
     }
   }
 
-  /**
-   * Helper method to set up CreateNewJPAEntityCommand with test data.
-   */
+  /** Helper method to set up CreateNewJPAEntityCommand with test data. */
   private void setupCreateNewJPAEntityCommand(Path cwd, String packageName, String fileName) {
     setField(createNewJPAEntityCommand, "cwd", cwd);
     setField(createNewJPAEntityCommand, "packageName", packageName);
     setField(createNewJPAEntityCommand, "fileName", fileName);
   }
 
-  /**
-   * Helper method to set private fields using reflection for testing purposes.
-   */
+  /** Helper method to set private fields using reflection for testing purposes. */
   private void setField(Object target, String fieldName, Object value) {
     try {
       var field = target.getClass().getDeclaredField(fieldName);
@@ -417,10 +410,9 @@ class CreateNewJPAEntityCommandTest {
     }
   }
 
-  /**
-   * Test double for CreateNewJPAEntityCommandService to control service behavior in tests.
-   */
-  private static class TestCreateNewJPAEntityCommandService extends CreateNewJPAEntityCommandService {
+  /** Test double for CreateNewJPAEntityCommandService to control service behavior in tests. */
+  private static class TestCreateNewJPAEntityCommandService
+      extends CreateNewJPAEntityCommandService {
     private boolean serviceCalled = false;
     private DataTransferObject<CreateNewJPAEntityResponse> responseToReturn;
     private Path lastCalledCwd;
@@ -470,3 +462,4 @@ class CreateNewJPAEntityCommandTest {
     }
   }
 }
+

--- a/src/test/java/io/github/syntaxpresso/core/command/GetAllFilesCommandTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/command/GetAllFilesCommandTest.java
@@ -1,0 +1,623 @@
+package io.github.syntaxpresso.core.command;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.syntaxpresso.core.command.dto.FileResponse;
+import io.github.syntaxpresso.core.command.dto.GetAllFilesResponse;
+import io.github.syntaxpresso.core.command.extra.JavaFileTemplate;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.command.GetAllFilesCommandService;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Comprehensive tests for GetAllFilesCommand.
+ * 
+ * Example usage:
+ * <pre>
+ * GetAllFilesCommand command = new GetAllFilesCommand(service);
+ * // Set command options: --cwd /path/to/project --file-type ENUM --language JAVA --ide NONE
+ * DataTransferObject&lt;GetAllFilesResponse&gt; result = command.call();
+ * if (result.getSucceed()) {
+ *     GetAllFilesResponse response = result.getData();
+ *     System.out.println("Found " + response.getResponse().size() + " files");
+ * }
+ * </pre>
+ */
+@DisplayName("GetAllFilesCommand Tests")
+class GetAllFilesCommandTest {
+  private GetAllFilesCommand getAllFilesCommand;
+  private TestGetAllFilesCommandService testService;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    this.testService = new TestGetAllFilesCommandService();
+    this.getAllFilesCommand = new GetAllFilesCommand(this.testService);
+  }
+
+  @Nested
+  @DisplayName("Java language support tests")
+  class JavaLanguageSupportTests {
+    @Test
+    @DisplayName("Should successfully retrieve enum files")
+    void shouldSuccessfullyRetrieveEnumFiles() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse expectedResponse = createSuccessResponse("StateEnum", "com.example.enums", "/path/to/StateEnum.java");
+      testService.setSuccessResponse(expectedResponse);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.ENUM, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(1, result.getData().getResponse().size());
+      assertEquals("StateEnum", result.getData().getResponse().get(0).getType());
+      assertEquals("com.example.enums", result.getData().getResponse().get(0).getPackagePath());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(JavaFileTemplate.ENUM, testService.getLastCalledFileType());
+    }
+
+    @Test
+    @DisplayName("Should successfully retrieve class files")
+    void shouldSuccessfullyRetrieveClassFiles() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse expectedResponse = createSuccessResponse("UserService", "com.example.service", "/path/to/UserService.java");
+      testService.setSuccessResponse(expectedResponse);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.VSCODE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(1, result.getData().getResponse().size());
+      assertEquals("UserService", result.getData().getResponse().get(0).getType());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(JavaFileTemplate.CLASS, testService.getLastCalledFileType());
+    }
+
+    @Test
+    @DisplayName("Should successfully retrieve interface files")
+    void shouldSuccessfullyRetrieveInterfaceFiles() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse expectedResponse = createSuccessResponse("UserRepository", "com.example.repository", "/path/to/UserRepository.java");
+      testService.setSuccessResponse(expectedResponse);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.INTERFACE, SupportedLanguage.JAVA, SupportedIDE.NEOVIM);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(1, result.getData().getResponse().size());
+      assertEquals("UserRepository", result.getData().getResponse().get(0).getType());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(JavaFileTemplate.INTERFACE, testService.getLastCalledFileType());
+    }
+
+    @Test
+    @DisplayName("Should successfully retrieve record files")
+    void shouldSuccessfullyRetrieveRecordFiles() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse expectedResponse = createSuccessResponse("UserDto", "com.example.dto", "/path/to/UserDto.java");
+      testService.setSuccessResponse(expectedResponse);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.RECORD, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(1, result.getData().getResponse().size());
+      assertEquals("UserDto", result.getData().getResponse().get(0).getType());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(JavaFileTemplate.RECORD, testService.getLastCalledFileType());
+    }
+
+    @Test
+    @DisplayName("Should successfully retrieve annotation files")
+    void shouldSuccessfullyRetrieveAnnotationFiles() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse expectedResponse = createSuccessResponse("CustomAnnotation", "com.example.annotations", "/path/to/CustomAnnotation.java");
+      testService.setSuccessResponse(expectedResponse);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.ANNOTATION, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(1, result.getData().getResponse().size());
+      assertEquals("CustomAnnotation", result.getData().getResponse().get(0).getType());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(JavaFileTemplate.ANNOTATION, testService.getLastCalledFileType());
+    }
+
+    @Test
+    @DisplayName("Should return empty list when no files found")
+    void shouldReturnEmptyListWhenNoFilesFound() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse emptyResponse = new GetAllFilesResponse();
+      testService.setSuccessResponse(emptyResponse);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.ENUM, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(0, result.getData().getResponse().size());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle multiple files of same type")
+    void shouldHandleMultipleFilesOfSameType() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse multipleFilesResponse = createMultipleFilesResponse();
+      testService.setSuccessResponse(multipleFilesResponse);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.ENUM, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(3, result.getData().getResponse().size());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle service error responses for Java")
+    void shouldHandleServiceErrorResponsesForJava() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      testService.setErrorResponse("Directory not found: " + projectDir);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.ENUM, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertNull(result.getData());
+      assertTrue(result.getErrorReason().contains("Directory not found"));
+      assertTrue(testService.wasServiceCalled());
+    }
+  }
+
+  @Nested
+  @DisplayName("Language validation tests")
+  class LanguageValidationTests {
+    @Test
+    @DisplayName("Should handle null language gracefully")
+    void shouldHandleNullLanguageGracefully() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.ENUM, SupportedLanguage.JAVA, SupportedIDE.NONE);
+      // Manually override the language field to null to test null handling
+      setField(getAllFilesCommand, "language", null);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then - should handle null gracefully and return error
+      assertFalse(result.getSucceed());
+      assertNull(result.getData());
+      assertEquals("Language not supported.", result.getErrorReason());
+      assertFalse(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should process Java language successfully with default settings")
+    void shouldProcessJavaLanguageSuccessfullyWithDefaultSettings() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse("TestFile", "com.test", "/path/to/TestFile.java");
+      testService.setSuccessResponse(response);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals("TestFile", result.getData().getResponse().get(0).getType());
+    }
+  }
+
+  @Nested
+  @DisplayName("File type tests")
+  class FileTypeTests {
+    @Test
+    @DisplayName("Should handle all Java file template types")
+    void shouldHandleAllJavaFileTemplateTypes() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      
+      // Test each file template type
+      for (JavaFileTemplate fileTemplate : JavaFileTemplate.values()) {
+        GetAllFilesResponse response = createSuccessResponse(
+            fileTemplate.name() + "Test", 
+            "com.example." + fileTemplate.name().toLowerCase(), 
+            "/path/to/" + fileTemplate.name() + "Test.java"
+        );
+        testService.setSuccessResponse(response);
+        setupGetAllFilesCommand(projectDir, fileTemplate, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+        // When
+        DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+        // Then
+        assertTrue(result.getSucceed(), "Failed for file template: " + fileTemplate);
+        assertNotNull(result.getData());
+        assertEquals(fileTemplate, testService.getLastCalledFileType());
+        assertEquals(1, result.getData().getResponse().size());
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("IDE-specific behavior tests")
+  class IDESpecificBehaviorTests {
+    @Test
+    @DisplayName("Should handle NONE IDE correctly")
+    void shouldHandleNoneIDECorrectly() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse("NoneIDETest", "com.example", "/path/to/NoneIDETest.java");
+      testService.setSuccessResponse(response);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals("NoneIDETest", result.getData().getResponse().get(0).getType());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle VSCODE IDE correctly")
+    void shouldHandleVSCodeIDECorrectly() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse("VSCodeTest", "com.example", "/path/to/VSCodeTest.java");
+      testService.setSuccessResponse(response);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.INTERFACE, SupportedLanguage.JAVA, SupportedIDE.VSCODE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals("VSCodeTest", result.getData().getResponse().get(0).getType());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle NEOVIM IDE correctly")
+    void shouldHandleNeovimIDECorrectly() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse("NeovimTest", "com.example", "/path/to/NeovimTest.java");
+      testService.setSuccessResponse(response);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.RECORD, SupportedLanguage.JAVA, SupportedIDE.NEOVIM);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals("NeovimTest", result.getData().getResponse().get(0).getType());
+      assertTrue(testService.wasServiceCalled());
+    }
+  }
+
+  @Nested
+  @DisplayName("Command configuration tests")
+  class CommandConfigurationTests {
+    @Test
+    @DisplayName("Should have correct picocli annotations")
+    void shouldHaveCorrectPicocliAnnotations() {
+      // Verify the class implements Callable
+      assertTrue(Callable.class.isAssignableFrom(GetAllFilesCommand.class));
+
+      // Verify command annotation exists
+      assertTrue(GetAllFilesCommand.class.isAnnotationPresent(picocli.CommandLine.Command.class));
+
+      // Verify command properties
+      picocli.CommandLine.Command commandAnnotation =
+          GetAllFilesCommand.class.getAnnotation(picocli.CommandLine.Command.class);
+      assertEquals("get-all-files", commandAnnotation.name());
+      assertEquals("Get a list of all files in the current working directory by it's type.", commandAnnotation.description()[0]);
+    }
+
+    @Test
+    @DisplayName("Should handle all required options")
+    void shouldHandleAllRequiredOptions() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse("OptionsTest", "com.example", "/path/to/OptionsTest.java");
+      testService.setSuccessResponse(response);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertEquals(projectDir, testService.getLastCalledCwd());
+      assertEquals(JavaFileTemplate.CLASS, testService.getLastCalledFileType());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should return DataTransferObject with correct generic type")
+    void shouldReturnDataTransferObjectWithCorrectGenericType() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse("GenericTest", "com.example", "/path/to/GenericTest.java");
+      testService.setSuccessResponse(response);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertTrue(result.getData() instanceof GetAllFilesResponse);
+      assertEquals(GetAllFilesResponse.class, result.getData().getClass());
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge case tests")
+  class EdgeCaseTests {
+    @Test
+    @DisplayName("Should handle service validation errors")
+    void shouldHandleServiceValidationErrors() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      testService.setErrorResponse("Invalid directory path.");
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertEquals("Invalid directory path.", result.getErrorReason());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle directory not found error")
+    void shouldHandleDirectoryNotFoundError() throws Exception {
+      // Given
+      Path nonExistentDir = tempDir.resolve("non-existent");
+      testService.setErrorResponse("Directory not found: " + nonExistentDir);
+      setupGetAllFilesCommand(nonExistentDir, JavaFileTemplate.ENUM, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertTrue(result.getErrorReason().contains("Directory not found"));
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle service returning null response")
+    void shouldHandleServiceReturningNullResponse() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      testService.setNullResponse();
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNull(result.getData());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should handle files with complex package paths")
+    void shouldHandleFilesWithComplexPackagePaths() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse(
+          "ComplexClass", 
+          "com.example.deep.nested.package", 
+          "/path/to/deep/nested/ComplexClass.java"
+      );
+      testService.setSuccessResponse(response);
+      setupGetAllFilesCommand(projectDir, JavaFileTemplate.CLASS, SupportedLanguage.JAVA, SupportedIDE.NONE);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals("com.example.deep.nested.package", result.getData().getResponse().get(0).getPackagePath());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should use default language and IDE when not specified")
+    void shouldUseDefaultLanguageAndIDEWhenNotSpecified() throws Exception {
+      // Given
+      Path projectDir = createTestProjectStructure();
+      GetAllFilesResponse response = createSuccessResponse("DefaultTest", "com.example", "/path/to/DefaultTest.java");
+      testService.setSuccessResponse(response);
+      // Don't explicitly set language and IDE - should use defaults
+      setupGetAllFilesCommandWithDefaults(projectDir, JavaFileTemplate.CLASS);
+
+      // When
+      DataTransferObject<GetAllFilesResponse> result = getAllFilesCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals("DefaultTest", result.getData().getResponse().get(0).getType());
+    }
+  }
+
+  private Path createTestProjectStructure() throws IOException {
+    Path projectDir = tempDir.resolve("test-project");
+    Files.createDirectories(projectDir);
+    
+    // Create standard Maven directory structure
+    Files.createDirectories(projectDir.resolve("src/main/java"));
+    Files.createDirectories(projectDir.resolve("src/test/java"));
+    
+    return projectDir;
+  }
+
+  private GetAllFilesResponse createSuccessResponse(String type, String packagePath, String filePath) {
+    FileResponse fileResponse = new FileResponse();
+    fileResponse.setType(type);
+    fileResponse.setPackagePath(packagePath);
+    fileResponse.setFilePath(filePath);
+    
+    GetAllFilesResponse response = new GetAllFilesResponse();
+    response.getResponse().add(fileResponse);
+    
+    return response;
+  }
+
+  private GetAllFilesResponse createMultipleFilesResponse() {
+    GetAllFilesResponse response = new GetAllFilesResponse();
+    
+    FileResponse enum1 = new FileResponse();
+    enum1.setType("StateEnum");
+    enum1.setPackagePath("com.example.enums");
+    enum1.setFilePath("/path/to/StateEnum.java");
+    
+    FileResponse enum2 = new FileResponse();
+    enum2.setType("StatusEnum");
+    enum2.setPackagePath("com.example.enums");
+    enum2.setFilePath("/path/to/StatusEnum.java");
+    
+    FileResponse enum3 = new FileResponse();
+    enum3.setType("TypeEnum");
+    enum3.setPackagePath("com.example.types");
+    enum3.setFilePath("/path/to/TypeEnum.java");
+    
+    response.getResponse().add(enum1);
+    response.getResponse().add(enum2);
+    response.getResponse().add(enum3);
+    
+    return response;
+  }
+
+  private void setupGetAllFilesCommand(Path cwd, JavaFileTemplate fileType, SupportedLanguage language, SupportedIDE ide) {
+    setField(getAllFilesCommand, "cwd", cwd);
+    setField(getAllFilesCommand, "fileType", fileType);
+    setField(getAllFilesCommand, "language", language);
+    setField(getAllFilesCommand, "ide", ide);
+  }
+
+  private void setupGetAllFilesCommandWithDefaults(Path cwd, JavaFileTemplate fileType) {
+    setField(getAllFilesCommand, "cwd", cwd);
+    setField(getAllFilesCommand, "fileType", fileType);
+    // Don't set language and IDE - let them use defaults
+  }
+
+  private void setField(Object target, String fieldName, Object value) {
+    try {
+      var field = target.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(target, value);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to set field " + fieldName, e);
+    }
+  }
+
+
+  /**
+   * Test implementation of GetAllFilesCommandService that captures method calls and allows setting
+   * predefined responses.
+   */
+  private static class TestGetAllFilesCommandService extends GetAllFilesCommandService {
+    private boolean serviceCalled = false;
+    private Path lastCalledCwd;
+    private JavaFileTemplate lastCalledFileType;
+    private DataTransferObject<GetAllFilesResponse> responseToReturn;
+
+    public TestGetAllFilesCommandService() {
+      super(null); // Service not needed for testing
+    }
+
+    @Override
+    public DataTransferObject<GetAllFilesResponse> run(Path cwd, JavaFileTemplate fileType) {
+      this.serviceCalled = true;
+      this.lastCalledCwd = cwd;
+      this.lastCalledFileType = fileType;
+      return this.responseToReturn;
+    }
+
+    public void setSuccessResponse(GetAllFilesResponse response) {
+      this.responseToReturn = DataTransferObject.success(response);
+    }
+
+    public void setErrorResponse(String errorMessage) {
+      this.responseToReturn = DataTransferObject.error(errorMessage);
+    }
+
+    public void setNullResponse() {
+      this.responseToReturn = DataTransferObject.success();
+    }
+
+    public boolean wasServiceCalled() {
+      return this.serviceCalled;
+    }
+
+    public Path getLastCalledCwd() {
+      return this.lastCalledCwd;
+    }
+
+    public JavaFileTemplate getLastCalledFileType() {
+      return this.lastCalledFileType;
+    }
+  }
+}

--- a/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/JavaLanguageServiceTest.java
@@ -10,13 +10,16 @@ import io.github.syntaxpresso.core.common.TSFile;
 import io.github.syntaxpresso.core.common.extra.SupportedIDE;
 import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
 import io.github.syntaxpresso.core.service.extra.JavaIdentifierType;
+import io.github.syntaxpresso.core.service.java.language.AnnotationDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.AnnotationService;
 import io.github.syntaxpresso.core.service.java.language.ClassDeclarationService;
+import io.github.syntaxpresso.core.service.java.language.EnumDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.FieldDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.FormalParameterService;
 import io.github.syntaxpresso.core.service.java.language.ImportDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.InterfaceDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.LocalVariableDeclarationService;
+import io.github.syntaxpresso.core.service.java.language.RecordDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.MethodDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.PackageDeclarationService;
 import io.github.syntaxpresso.core.service.java.language.VariableNamingService;
@@ -61,6 +64,9 @@ class JavaLanguageServiceTest {
     ImportDeclarationService importDeclarationService = new ImportDeclarationService();
     LocalVariableDeclarationService localVariableDeclarationService =
         new LocalVariableDeclarationService();
+    EnumDeclarationService enumDeclarationService = new EnumDeclarationService();
+    RecordDeclarationService recordDeclarationService = new RecordDeclarationService();
+    AnnotationDeclarationService annotationDeclarationService = new AnnotationDeclarationService();
     AnnotationService annotationService = new AnnotationService();
     InterfaceDeclarationService interfaceDeclarationService = new InterfaceDeclarationService();
 
@@ -70,6 +76,9 @@ class JavaLanguageServiceTest {
             variableNamingService,
             classDeclarationService,
             interfaceDeclarationService,
+            enumDeclarationService,
+            recordDeclarationService,
+            annotationDeclarationService,
             packageDeclarationService,
             importDeclarationService,
             localVariableDeclarationService,

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/AnnotationDeclarationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/AnnotationDeclarationServiceTest.java
@@ -1,0 +1,424 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.syntaxpresso.core.common.TSFile;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.treesitter.TSNode;
+
+@DisplayName("AnnotationDeclarationService Tests")
+class AnnotationDeclarationServiceTest {
+  private AnnotationDeclarationService annotationDeclarationService;
+
+  private static final String SIMPLE_ANNOTATION_CODE =
+      """
+      public @interface SimpleAnnotation {
+          String value();
+      }
+      """;
+
+  private static final String COMPLEX_ANNOTATION_CODE =
+      """
+      package com.example;
+
+      import java.lang.annotation.ElementType;
+      import java.lang.annotation.Retention;
+      import java.lang.annotation.RetentionPolicy;
+      import java.lang.annotation.Target;
+
+      @Target({ElementType.TYPE, ElementType.METHOD})
+      @Retention(RetentionPolicy.RUNTIME)
+      public @interface ValidatedService {
+          String name() default "";
+          Class<?>[] groups() default {};
+          boolean required() default true;
+          int priority() default 0;
+      }
+      """;
+
+  private static final String MULTIPLE_ANNOTATIONS_CODE =
+      """
+      package com.example;
+
+      @interface InternalAnnotation {
+          String value();
+      }
+
+      public @interface PublicAnnotation {
+          int number();
+      }
+
+      @interface AnotherAnnotation {
+          boolean flag() default false;
+      }
+      """;
+
+  private static final String NO_PUBLIC_ANNOTATION_CODE =
+      """
+      package com.example;
+
+      @interface InternalAnnotation {
+          String value1();
+      }
+
+      @interface AnotherInternalAnnotation {
+          String value2();
+      }
+      """;
+
+  @BeforeEach
+  void setUp() {
+    this.annotationDeclarationService = new AnnotationDeclarationService();
+  }
+
+  @Nested
+  @DisplayName("findAnnotationByName Tests")
+  class FindAnnotationByNameTests {
+
+    @Test
+    @DisplayName("Should find annotation by exact name")
+    void shouldFindAnnotationByExactName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ANNOTATION_CODE);
+      Optional<TSNode> result =
+          annotationDeclarationService.findAnnotationByName(tsFile, "SimpleAnnotation");
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find complex annotation by name")
+    void shouldFindComplexAnnotationByName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_ANNOTATION_CODE);
+      Optional<TSNode> result =
+          annotationDeclarationService.findAnnotationByName(tsFile, "ValidatedService");
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find specific annotation from multiple annotations")
+    void shouldFindSpecificAnnotationFromMultiple() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_ANNOTATIONS_CODE);
+
+      Optional<TSNode> internalResult =
+          annotationDeclarationService.findAnnotationByName(tsFile, "InternalAnnotation");
+      Optional<TSNode> publicResult =
+          annotationDeclarationService.findAnnotationByName(tsFile, "PublicAnnotation");
+      Optional<TSNode> anotherResult =
+          annotationDeclarationService.findAnnotationByName(tsFile, "AnotherAnnotation");
+
+      assertTrue(internalResult.isPresent());
+      assertTrue(publicResult.isPresent());
+      assertTrue(anotherResult.isPresent());
+      assertEquals("annotation_type_declaration", internalResult.get().getType());
+      assertEquals("annotation_type_declaration", publicResult.get().getType());
+      assertEquals("annotation_type_declaration", anotherResult.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when annotation not found")
+    void shouldReturnEmptyWhenAnnotationNotFound() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ANNOTATION_CODE);
+      Optional<TSNode> result =
+          annotationDeclarationService.findAnnotationByName(tsFile, "NonExistentAnnotation");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result =
+          annotationDeclarationService.findAnnotationByName(null, "SimpleAnnotation");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when annotation name is null")
+    void shouldReturnEmptyWhenAnnotationNameIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ANNOTATION_CODE);
+      Optional<TSNode> result = annotationDeclarationService.findAnnotationByName(tsFile, null);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when annotation name is empty")
+    void shouldReturnEmptyWhenAnnotationNameIsEmpty() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ANNOTATION_CODE);
+      Optional<TSNode> result = annotationDeclarationService.findAnnotationByName(tsFile, "");
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getPublicAnnotation Tests")
+  class GetPublicAnnotationTests {
+
+    @Test
+    @DisplayName("Should get public annotation matching filename")
+    void shouldGetPublicAnnotationMatchingFilename(@TempDir Path tempDir) throws IOException {
+      Path annotationFile = tempDir.resolve("SimpleAnnotation.java");
+      Files.writeString(annotationFile, SIMPLE_ANNOTATION_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotationFile);
+
+      Optional<TSNode> result = annotationDeclarationService.getPublicAnnotation(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should get public annotation matching filename for complex annotation")
+    void shouldGetPublicAnnotationMatchingFilenameForComplex(@TempDir Path tempDir)
+        throws IOException {
+      Path annotationFile = tempDir.resolve("ValidatedService.java");
+      Files.writeString(annotationFile, COMPLEX_ANNOTATION_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotationFile);
+
+      Optional<TSNode> result = annotationDeclarationService.getPublicAnnotation(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when filename doesn't match any annotation")
+    void shouldReturnEmptyWhenFilenameDoesntMatchAnyAnnotation(@TempDir Path tempDir)
+        throws IOException {
+      Path annotationFile = tempDir.resolve("WrongName.java");
+      Files.writeString(annotationFile, MULTIPLE_ANNOTATIONS_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotationFile);
+
+      Optional<TSNode> result = annotationDeclarationService.getPublicAnnotation(tsFile);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when no public annotation exists")
+    void shouldReturnEmptyWhenNoPublicAnnotationExists(@TempDir Path tempDir) throws IOException {
+      Path annotationFile = tempDir.resolve("NoPublic.java");
+      Files.writeString(annotationFile, NO_PUBLIC_ANNOTATION_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotationFile);
+
+      Optional<TSNode> result = annotationDeclarationService.getPublicAnnotation(tsFile);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should fallback to first public annotation when no filename available")
+    void shouldFallbackToFirstPublicAnnotationWhenNoFilenameAvailable() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_ANNOTATIONS_CODE);
+
+      Optional<TSNode> result = annotationDeclarationService.getPublicAnnotation(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result = annotationDeclarationService.getPublicAnnotation(null);
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getAnnotationNameNode Tests")
+  class GetAnnotationNameNodeTests {
+
+    @Test
+    @DisplayName("Should get annotation name node from simple annotation")
+    void shouldGetAnnotationNameNodeFromSimpleAnnotation() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ANNOTATION_CODE);
+      Optional<TSNode> annotationNode =
+          annotationDeclarationService.findAnnotationByName(tsFile, "SimpleAnnotation");
+
+      assertTrue(annotationNode.isPresent());
+      Optional<TSNode> nameNode =
+          annotationDeclarationService.getAnnotationNameNode(tsFile, annotationNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("SimpleAnnotation", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get annotation name node from complex annotation")
+    void shouldGetAnnotationNameNodeFromComplexAnnotation() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_ANNOTATION_CODE);
+      Optional<TSNode> annotationNode =
+          annotationDeclarationService.findAnnotationByName(tsFile, "ValidatedService");
+
+      assertTrue(annotationNode.isPresent());
+      Optional<TSNode> nameNode =
+          annotationDeclarationService.getAnnotationNameNode(tsFile, annotationNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("ValidatedService", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get annotation name node from multiple annotations")
+    void shouldGetAnnotationNameNodeFromMultipleAnnotations() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_ANNOTATIONS_CODE);
+      Optional<TSNode> publicAnnotationNode =
+          annotationDeclarationService.findAnnotationByName(tsFile, "PublicAnnotation");
+
+      assertTrue(publicAnnotationNode.isPresent());
+      Optional<TSNode> nameNode =
+          annotationDeclarationService.getAnnotationNameNode(tsFile, publicAnnotationNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("PublicAnnotation", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ANNOTATION_CODE);
+      Optional<TSNode> annotationNode =
+          annotationDeclarationService.findAnnotationByName(tsFile, "SimpleAnnotation");
+
+      assertTrue(annotationNode.isPresent());
+      Optional<TSNode> nameNode =
+          annotationDeclarationService.getAnnotationNameNode(null, annotationNode.get());
+
+      assertFalse(nameNode.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when node is not annotation_type_declaration")
+    void shouldReturnEmptyWhenNodeIsNotAnnotationTypeDeclaration() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ANNOTATION_CODE);
+      TSNode rootNode = tsFile.getTree().getRootNode();
+
+      Optional<TSNode> nameNode =
+          annotationDeclarationService.getAnnotationNameNode(tsFile, rootNode);
+
+      assertFalse(nameNode.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases and Error Handling")
+  class EdgeCasesAndErrorHandlingTests {
+
+    @Test
+    @DisplayName("Should handle annotation with default values")
+    void shouldHandleAnnotationWithDefaultValues() {
+      String annotationWithDefaultsCode =
+          """
+          public @interface Config {
+              String name() default "default";
+              int timeout() default 30;
+              boolean enabled() default true;
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotationWithDefaultsCode);
+      Optional<TSNode> result = annotationDeclarationService.findAnnotationByName(tsFile, "Config");
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle annotation with array parameters")
+    void shouldHandleAnnotationWithArrayParameters() {
+      String annotationWithArraysCode =
+          """
+          public @interface Roles {
+              String[] value();
+              Class<?>[] types() default {};
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotationWithArraysCode);
+      Optional<TSNode> result = annotationDeclarationService.findAnnotationByName(tsFile, "Roles");
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle nested annotations")
+    void shouldHandleNestedAnnotations() {
+      String nestedAnnotationCode =
+          """
+          public class OuterClass {
+              public @interface InnerAnnotation {
+                  String value();
+              }
+              
+              private @interface PrivateAnnotation {
+                  int number();
+              }
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, nestedAnnotationCode);
+      Optional<TSNode> result =
+          annotationDeclarationService.findAnnotationByName(tsFile, "InnerAnnotation");
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle marker annotation")
+    void shouldHandleMarkerAnnotation() {
+      String markerAnnotationCode =
+          """
+          public @interface MarkerAnnotation {
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, markerAnnotationCode);
+      Optional<TSNode> result =
+          annotationDeclarationService.findAnnotationByName(tsFile, "MarkerAnnotation");
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle annotation with meta-annotations")
+    void shouldHandleAnnotationWithMetaAnnotations() {
+      String metaAnnotatedCode =
+          """
+          @Target(ElementType.METHOD)
+          @Retention(RetentionPolicy.RUNTIME)
+          @Documented
+          @Inherited
+          public @interface CustomValidator {
+              String message() default "Validation failed";
+              Class<?>[] groups() default {};
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, metaAnnotatedCode);
+      Optional<TSNode> result =
+          annotationDeclarationService.findAnnotationByName(tsFile, "CustomValidator");
+
+      assertTrue(result.isPresent());
+      assertEquals("annotation_type_declaration", result.get().getType());
+    }
+  }
+}

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/EnumDeclarationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/EnumDeclarationServiceTest.java
@@ -1,0 +1,403 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.syntaxpresso.core.common.TSFile;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.treesitter.TSNode;
+
+@DisplayName("EnumDeclarationService Tests")
+class EnumDeclarationServiceTest {
+  private EnumDeclarationService enumDeclarationService;
+
+  private static final String SIMPLE_ENUM_CODE =
+      """
+      public enum Color {
+          RED, GREEN, BLUE
+      }
+      """;
+
+  private static final String COMPLEX_ENUM_CODE =
+      """
+      package com.example;
+
+      import java.util.Arrays;
+
+      public enum Status {
+          ACTIVE("active", 1),
+          INACTIVE("inactive", 0),
+          PENDING("pending", 2);
+
+          private final String name;
+          private final int code;
+
+          Status(String name, int code) {
+              this.name = name;
+              this.code = code;
+          }
+
+          public String getName() {
+              return name;
+          }
+
+          public int getCode() {
+              return code;
+          }
+      }
+      """;
+
+  private static final String MULTIPLE_ENUMS_CODE =
+      """
+      package com.example;
+
+      enum InternalEnum {
+          INTERNAL_VALUE
+      }
+
+      public enum PublicEnum {
+          PUBLIC_VALUE
+      }
+
+      enum AnotherEnum {
+          ANOTHER_VALUE
+      }
+      """;
+
+  private static final String NO_PUBLIC_ENUM_CODE =
+      """
+      package com.example;
+
+      enum InternalEnum {
+          VALUE1
+      }
+
+      enum AnotherInternalEnum {
+          VALUE2
+      }
+      """;
+
+  @BeforeEach
+  void setUp() {
+    this.enumDeclarationService = new EnumDeclarationService();
+  }
+
+  @Nested
+  @DisplayName("findEnumByName Tests")
+  class FindEnumByNameTests {
+
+    @Test
+    @DisplayName("Should find enum by exact name")
+    void shouldFindEnumByExactName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ENUM_CODE);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "Color");
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find complex enum by name")
+    void shouldFindComplexEnumByName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_ENUM_CODE);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "Status");
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find specific enum from multiple enums")
+    void shouldFindSpecificEnumFromMultiple() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_ENUMS_CODE);
+
+      Optional<TSNode> internalResult =
+          enumDeclarationService.findEnumByName(tsFile, "InternalEnum");
+      Optional<TSNode> publicResult = enumDeclarationService.findEnumByName(tsFile, "PublicEnum");
+      Optional<TSNode> anotherResult = enumDeclarationService.findEnumByName(tsFile, "AnotherEnum");
+
+      assertTrue(internalResult.isPresent());
+      assertTrue(publicResult.isPresent());
+      assertTrue(anotherResult.isPresent());
+      assertEquals("enum_declaration", internalResult.get().getType());
+      assertEquals("enum_declaration", publicResult.get().getType());
+      assertEquals("enum_declaration", anotherResult.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when enum not found")
+    void shouldReturnEmptyWhenEnumNotFound() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ENUM_CODE);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "NonExistentEnum");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(null, "Color");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when enum name is null")
+    void shouldReturnEmptyWhenEnumNameIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ENUM_CODE);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, null);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when enum name is empty")
+    void shouldReturnEmptyWhenEnumNameIsEmpty() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ENUM_CODE);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "");
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getPublicEnum Tests")
+  class GetPublicEnumTests {
+
+    @Test
+    @DisplayName("Should get public enum matching filename")
+    void shouldGetPublicEnumMatchingFilename(@TempDir Path tempDir) throws IOException {
+      Path enumFile = tempDir.resolve("Color.java");
+      Files.writeString(enumFile, SIMPLE_ENUM_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, enumFile);
+
+      Optional<TSNode> result = enumDeclarationService.getPublicEnum(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should get public enum matching filename for complex enum")
+    void shouldGetPublicEnumMatchingFilenameForComplex(@TempDir Path tempDir) throws IOException {
+      Path enumFile = tempDir.resolve("Status.java");
+      Files.writeString(enumFile, COMPLEX_ENUM_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, enumFile);
+
+      Optional<TSNode> result = enumDeclarationService.getPublicEnum(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when filename doesn't match any enum")
+    void shouldReturnEmptyWhenFilenameDoesntMatchAnyEnum(@TempDir Path tempDir) throws IOException {
+      Path enumFile = tempDir.resolve("WrongName.java");
+      Files.writeString(enumFile, MULTIPLE_ENUMS_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, enumFile);
+
+      Optional<TSNode> result = enumDeclarationService.getPublicEnum(tsFile);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when no public enum exists")
+    void shouldReturnEmptyWhenNoPublicEnumExists(@TempDir Path tempDir) throws IOException {
+      Path enumFile = tempDir.resolve("NoPublic.java");
+      Files.writeString(enumFile, NO_PUBLIC_ENUM_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, enumFile);
+
+      Optional<TSNode> result = enumDeclarationService.getPublicEnum(tsFile);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should fallback to first public enum when no filename available")
+    void shouldFallbackToFirstPublicEnumWhenNoFilenameAvailable() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_ENUMS_CODE);
+
+      Optional<TSNode> result = enumDeclarationService.getPublicEnum(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result = enumDeclarationService.getPublicEnum(null);
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getEnumNameNode Tests")
+  class GetEnumNameNodeTests {
+
+    @Test
+    @DisplayName("Should get enum name node from simple enum")
+    void shouldGetEnumNameNodeFromSimpleEnum() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ENUM_CODE);
+      Optional<TSNode> enumNode = enumDeclarationService.findEnumByName(tsFile, "Color");
+
+      assertTrue(enumNode.isPresent());
+      Optional<TSNode> nameNode = enumDeclarationService.getEnumNameNode(tsFile, enumNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("Color", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get enum name node from complex enum")
+    void shouldGetEnumNameNodeFromComplexEnum() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_ENUM_CODE);
+      Optional<TSNode> enumNode = enumDeclarationService.findEnumByName(tsFile, "Status");
+
+      assertTrue(enumNode.isPresent());
+      Optional<TSNode> nameNode = enumDeclarationService.getEnumNameNode(tsFile, enumNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("Status", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get enum name node from multiple enums")
+    void shouldGetEnumNameNodeFromMultipleEnums() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_ENUMS_CODE);
+      Optional<TSNode> publicEnumNode = enumDeclarationService.findEnumByName(tsFile, "PublicEnum");
+
+      assertTrue(publicEnumNode.isPresent());
+      Optional<TSNode> nameNode =
+          enumDeclarationService.getEnumNameNode(tsFile, publicEnumNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("PublicEnum", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ENUM_CODE);
+      Optional<TSNode> enumNode = enumDeclarationService.findEnumByName(tsFile, "Color");
+
+      assertTrue(enumNode.isPresent());
+      Optional<TSNode> nameNode = enumDeclarationService.getEnumNameNode(null, enumNode.get());
+
+      assertFalse(nameNode.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when node is not enum_declaration")
+    void shouldReturnEmptyWhenNodeIsNotEnumDeclaration() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_ENUM_CODE);
+      TSNode rootNode = tsFile.getTree().getRootNode();
+
+      Optional<TSNode> nameNode = enumDeclarationService.getEnumNameNode(tsFile, rootNode);
+
+      assertFalse(nameNode.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases and Error Handling")
+  class EdgeCasesAndErrorHandlingTests {
+
+    @Test
+    @DisplayName("Should handle enum with methods and fields")
+    void shouldHandleEnumWithMethodsAndFields() {
+      String enumWithMethodsCode =
+          """
+          public enum Size {
+              SMALL(1), MEDIUM(2), LARGE(3);
+              
+              private final int value;
+              
+              Size(int value) {
+                  this.value = value;
+              }
+              
+              public int getValue() {
+                  return value;
+              }
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, enumWithMethodsCode);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "Size");
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle enum with annotations")
+    void shouldHandleEnumWithAnnotations() {
+      String annotatedEnumCode =
+          """
+          @Entity
+          @Table(name = "status")
+          public enum Status {
+              ACTIVE, INACTIVE
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotatedEnumCode);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "Status");
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle nested enums")
+    void shouldHandleNestedEnums() {
+      String nestedEnumCode =
+          """
+          public class OuterClass {
+              public enum InnerEnum {
+                  VALUE1, VALUE2
+              }
+              
+              private enum PrivateEnum {
+                  PRIVATE_VALUE
+              }
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, nestedEnumCode);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "InnerEnum");
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle empty enum")
+    void shouldHandleEmptyEnum() {
+      String emptyEnumCode =
+          """
+          public enum EmptyEnum {
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, emptyEnumCode);
+      Optional<TSNode> result = enumDeclarationService.findEnumByName(tsFile, "EmptyEnum");
+
+      assertTrue(result.isPresent());
+      assertEquals("enum_declaration", result.get().getType());
+    }
+  }
+}

--- a/src/test/java/io/github/syntaxpresso/core/service/java/language/RecordDeclarationServiceTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/service/java/language/RecordDeclarationServiceTest.java
@@ -1,0 +1,408 @@
+package io.github.syntaxpresso.core.service.java.language;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.syntaxpresso.core.common.TSFile;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.treesitter.TSNode;
+
+@DisplayName("RecordDeclarationService Tests")
+class RecordDeclarationServiceTest {
+  private RecordDeclarationService recordDeclarationService;
+
+  private static final String SIMPLE_RECORD_CODE =
+      """
+      public record Person(String name, int age) {}
+      """;
+
+  private static final String COMPLEX_RECORD_CODE =
+      """
+      package com.example;
+
+      import java.time.LocalDate;
+      import java.util.Objects;
+
+      public record Employee(
+          String firstName,
+          String lastName,
+          LocalDate birthDate,
+          double salary
+      ) {
+          public Employee {
+              Objects.requireNonNull(firstName);
+              Objects.requireNonNull(lastName);
+              if (salary < 0) {
+                  throw new IllegalArgumentException("Salary cannot be negative");
+              }
+          }
+
+          public String fullName() {
+              return firstName + " " + lastName;
+          }
+      }
+      """;
+
+  private static final String MULTIPLE_RECORDS_CODE =
+      """
+      package com.example;
+
+      record InternalRecord(String value) {}
+
+      public record PublicRecord(int id, String name) {}
+
+      record AnotherRecord(boolean flag) {}
+      """;
+
+  private static final String NO_PUBLIC_RECORD_CODE =
+      """
+      package com.example;
+
+      record InternalRecord(String value1) {}
+
+      record AnotherInternalRecord(String value2) {}
+      """;
+
+  @BeforeEach
+  void setUp() {
+    this.recordDeclarationService = new RecordDeclarationService();
+  }
+
+  @Nested
+  @DisplayName("findRecordByName Tests")
+  class FindRecordByNameTests {
+
+    @Test
+    @DisplayName("Should find record by exact name")
+    void shouldFindRecordByExactName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_RECORD_CODE);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "Person");
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find complex record by name")
+    void shouldFindComplexRecordByName() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_RECORD_CODE);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "Employee");
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should find specific record from multiple records")
+    void shouldFindSpecificRecordFromMultiple() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_RECORDS_CODE);
+
+      Optional<TSNode> internalResult =
+          recordDeclarationService.findRecordByName(tsFile, "InternalRecord");
+      Optional<TSNode> publicResult =
+          recordDeclarationService.findRecordByName(tsFile, "PublicRecord");
+      Optional<TSNode> anotherResult =
+          recordDeclarationService.findRecordByName(tsFile, "AnotherRecord");
+
+      assertTrue(internalResult.isPresent());
+      assertTrue(publicResult.isPresent());
+      assertTrue(anotherResult.isPresent());
+      assertEquals("record_declaration", internalResult.get().getType());
+      assertEquals("record_declaration", publicResult.get().getType());
+      assertEquals("record_declaration", anotherResult.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when record not found")
+    void shouldReturnEmptyWhenRecordNotFound() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_RECORD_CODE);
+      Optional<TSNode> result =
+          recordDeclarationService.findRecordByName(tsFile, "NonExistentRecord");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(null, "Person");
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when record name is null")
+    void shouldReturnEmptyWhenRecordNameIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_RECORD_CODE);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, null);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when record name is empty")
+    void shouldReturnEmptyWhenRecordNameIsEmpty() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_RECORD_CODE);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "");
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getPublicRecord Tests")
+  class GetPublicRecordTests {
+
+    @Test
+    @DisplayName("Should get public record matching filename")
+    void shouldGetPublicRecordMatchingFilename(@TempDir Path tempDir) throws IOException {
+      Path recordFile = tempDir.resolve("Person.java");
+      Files.writeString(recordFile, SIMPLE_RECORD_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, recordFile);
+
+      Optional<TSNode> result = recordDeclarationService.getPublicRecord(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should get public record matching filename for complex record")
+    void shouldGetPublicRecordMatchingFilenameForComplex(@TempDir Path tempDir) throws IOException {
+      Path recordFile = tempDir.resolve("Employee.java");
+      Files.writeString(recordFile, COMPLEX_RECORD_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, recordFile);
+
+      Optional<TSNode> result = recordDeclarationService.getPublicRecord(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when filename doesn't match any record")
+    void shouldReturnEmptyWhenFilenameDoesntMatchAnyRecord(@TempDir Path tempDir)
+        throws IOException {
+      Path recordFile = tempDir.resolve("WrongName.java");
+      Files.writeString(recordFile, MULTIPLE_RECORDS_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, recordFile);
+
+      Optional<TSNode> result = recordDeclarationService.getPublicRecord(tsFile);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when no public record exists")
+    void shouldReturnEmptyWhenNoPublicRecordExists(@TempDir Path tempDir) throws IOException {
+      Path recordFile = tempDir.resolve("NoPublic.java");
+      Files.writeString(recordFile, NO_PUBLIC_RECORD_CODE);
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, recordFile);
+
+      Optional<TSNode> result = recordDeclarationService.getPublicRecord(tsFile);
+
+      assertFalse(result.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should fallback to first public record when no filename available")
+    void shouldFallbackToFirstPublicRecordWhenNoFilenameAvailable() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_RECORDS_CODE);
+
+      Optional<TSNode> result = recordDeclarationService.getPublicRecord(tsFile);
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      Optional<TSNode> result = recordDeclarationService.getPublicRecord(null);
+
+      assertFalse(result.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("getRecordNameNode Tests")
+  class GetRecordNameNodeTests {
+
+    @Test
+    @DisplayName("Should get record name node from simple record")
+    void shouldGetRecordNameNodeFromSimpleRecord() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_RECORD_CODE);
+      Optional<TSNode> recordNode = recordDeclarationService.findRecordByName(tsFile, "Person");
+
+      assertTrue(recordNode.isPresent());
+      Optional<TSNode> nameNode =
+          recordDeclarationService.getRecordNameNode(tsFile, recordNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("Person", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get record name node from complex record")
+    void shouldGetRecordNameNodeFromComplexRecord() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, COMPLEX_RECORD_CODE);
+      Optional<TSNode> recordNode = recordDeclarationService.findRecordByName(tsFile, "Employee");
+
+      assertTrue(recordNode.isPresent());
+      Optional<TSNode> nameNode =
+          recordDeclarationService.getRecordNameNode(tsFile, recordNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("Employee", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should get record name node from multiple records")
+    void shouldGetRecordNameNodeFromMultipleRecords() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, MULTIPLE_RECORDS_CODE);
+      Optional<TSNode> publicRecordNode =
+          recordDeclarationService.findRecordByName(tsFile, "PublicRecord");
+
+      assertTrue(publicRecordNode.isPresent());
+      Optional<TSNode> nameNode =
+          recordDeclarationService.getRecordNameNode(tsFile, publicRecordNode.get());
+
+      assertTrue(nameNode.isPresent());
+      assertEquals("identifier", nameNode.get().getType());
+      assertEquals("PublicRecord", tsFile.getTextFromNode(nameNode.get()));
+    }
+
+    @Test
+    @DisplayName("Should return empty when TSFile is null")
+    void shouldReturnEmptyWhenTSFileIsNull() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_RECORD_CODE);
+      Optional<TSNode> recordNode = recordDeclarationService.findRecordByName(tsFile, "Person");
+
+      assertTrue(recordNode.isPresent());
+      Optional<TSNode> nameNode = recordDeclarationService.getRecordNameNode(null, recordNode.get());
+
+      assertFalse(nameNode.isPresent());
+    }
+
+    @Test
+    @DisplayName("Should return empty when node is not record_declaration")
+    void shouldReturnEmptyWhenNodeIsNotRecordDeclaration() {
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, SIMPLE_RECORD_CODE);
+      TSNode rootNode = tsFile.getTree().getRootNode();
+
+      Optional<TSNode> nameNode = recordDeclarationService.getRecordNameNode(tsFile, rootNode);
+
+      assertFalse(nameNode.isPresent());
+    }
+  }
+
+  @Nested
+  @DisplayName("Edge Cases and Error Handling")
+  class EdgeCasesAndErrorHandlingTests {
+
+    @Test
+    @DisplayName("Should handle record with generic parameters")
+    void shouldHandleRecordWithGenericParameters() {
+      String genericRecordCode =
+          """
+          public record Container<T>(T value) {}
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, genericRecordCode);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "Container");
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle record with annotations")
+    void shouldHandleRecordWithAnnotations() {
+      String annotatedRecordCode =
+          """
+          @Entity
+          @Table(name = "users")
+          public record User(
+              @Id Long id,
+              @Column(name = "username") String username
+          ) {}
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, annotatedRecordCode);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "User");
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle nested records")
+    void shouldHandleNestedRecords() {
+      String nestedRecordCode =
+          """
+          public class OuterClass {
+              public record InnerRecord(String value) {}
+              
+              private record PrivateRecord(int number) {}
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, nestedRecordCode);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "InnerRecord");
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle record with compact constructor")
+    void shouldHandleRecordWithCompactConstructor() {
+      String compactConstructorCode =
+          """
+          public record Range(int start, int end) {
+              public Range {
+                  if (start > end) {
+                      throw new IllegalArgumentException("Start cannot be greater than end");
+                  }
+              }
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, compactConstructorCode);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "Range");
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+
+    @Test
+    @DisplayName("Should handle record with static methods")
+    void shouldHandleRecordWithStaticMethods() {
+      String recordWithStaticMethodsCode =
+          """
+          public record Point(int x, int y) {
+              public static Point origin() {
+                  return new Point(0, 0);
+              }
+              
+              public double distanceFromOrigin() {
+                  return Math.sqrt(x * x + y * y);
+              }
+          }
+          """;
+      TSFile tsFile = new TSFile(SupportedLanguage.JAVA, recordWithStaticMethodsCode);
+      Optional<TSNode> result = recordDeclarationService.findRecordByName(tsFile, "Point");
+
+      assertTrue(result.isPresent());
+      assertEquals("record_declaration", result.get().getType());
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new command for retrieving all files of a specific Java type (class, interface, enum, record, annotation) from the current working directory, along with supporting services and DTOs. It also enhances the language service to support annotation, enum, and record declarations, and updates the command factory and core wiring to integrate these new capabilities.

**New command and supporting services:**

* Added the `GetAllFilesCommand` and its service, `GetAllFilesCommandService`, which enable listing all files of a specified Java type in a directory, returning their type, package path, and file path. [[1]](diffhunk://#diff-bd3afa6694b19bed7b30bcf4bf4ac36f349c9450182c2931f6d2049f19209a34R1-R53) [[2]](diffhunk://#diff-1c04688172ab01b6dcc58ecab5aa41f45ace1151c7aa2e029e345b176fb5b94cR1-R87)
* Introduced DTOs `FileResponse` and `GetAllFilesResponse` to structure the output of the new command. [[1]](diffhunk://#diff-8f658829dea7c48fac6ce14c3418c86ee2bfb01fff9497aa8b56e87ba99c3a1dR1-R14) [[2]](diffhunk://#diff-d57d97222a44c1c9eab4adbc2f5e13f84145cb50f892981e3ad474c3de215ddfR1-R15)

**Core and factory integration:**

* Registered the new command and service in the `Core` class and updated the `CommandFactory` to support instantiating `GetAllFilesCommand`. [[1]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777L25-R26) [[2]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R109-R118) [[3]](diffhunk://#diff-13b624bcdb527541bb3e838a21909a3d6f03ec08bad3788c5d634ccfed3275f9R16) [[4]](diffhunk://#diff-13b624bcdb527541bb3e838a21909a3d6f03ec08bad3788c5d634ccfed3275f9L38-R41)

**Java language service enhancements:**

* Added `EnumDeclarationService`, `RecordDeclarationService`, and `AnnotationDeclarationService` to the `JavaLanguageService`, and updated identifier type recognition to support enum, record, and annotation declarations. [[1]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R80-R92) [[2]](diffhunk://#diff-4e06ae448ab5b48fc994662360f4f72dc9947e24630a64069b15619cb9f5d635R7-R15) [[3]](diffhunk://#diff-4e06ae448ab5b48fc994662360f4f72dc9947e24630a64069b15619cb9f5d635R32-R34) [[4]](diffhunk://#diff-4e06ae448ab5b48fc994662360f4f72dc9947e24630a64069b15619cb9f5d635R85-R92)
* Implemented `AnnotationDeclarationService` to support finding and extracting public annotation declarations by name or as the first public annotation in a file.