### PR TITLE
Create GetJPAInfoCommand

### DIFF
--- a/src/main/java/io/github/syntaxpresso/core/Core.java
+++ b/src/main/java/io/github/syntaxpresso/core/Core.java
@@ -23,6 +23,7 @@ import picocli.CommandLine.Command;
       GetCursorPositionInfoCommand.class,
       CreateNewJPAEntityCommand.class,
       CreateJPARepositoryCommand.class,
+      GetJPAEntityInfoCommand.class,
       GetAllFilesCommand.class
     })
 public class Core {
@@ -104,8 +105,10 @@ public class Core {
         new GetCursorPositionInfoCommandService(javaLanguageService, pathHelper);
     CreateNewJPAEntityCommandService createNewJPAEntityCommandService =
         new CreateNewJPAEntityCommandService(javaLanguageService, createNewFileCommandService);
+    GetJPAEntityInfoCommandService getJPAEntityInfoCommandService =
+        new GetJPAEntityInfoCommandService(javaLanguageService);
     CreateJPARepositoryCommandService createJPARepositoryCommandService =
-        new CreateJPARepositoryCommandService(javaLanguageService, createNewFileCommandService);
+        new CreateJPARepositoryCommandService(javaLanguageService, createNewFileCommandService, getJPAEntityInfoCommandService);
     GetAllFilesCommandService getAllFilesCommandService =
         new GetAllFilesCommandService(javaLanguageService);
     return new CommandFactory(
@@ -115,6 +118,7 @@ public class Core {
         getCursorPositionInfoCommandService,
         createNewJPAEntityCommandService,
         createJPARepositoryCommandService,
+        getJPAEntityInfoCommandService,
         getAllFilesCommandService);
   }
 }

--- a/src/main/java/io/github/syntaxpresso/core/command/GetJPAEntityInfoCommand.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/GetJPAEntityInfoCommand.java
@@ -1,40 +1,57 @@
-// package io.github.syntaxpresso.core.command;
-//
-// import io.github.syntaxpresso.core.command.dto.GetJPAEntityInfoResponse;
-// import io.github.syntaxpresso.core.common.DataTransferObject;
-// import io.github.syntaxpresso.core.common.extra.SupportedIDE;
-// import io.github.syntaxpresso.core.service.java.JavaCommandService;
-// import java.nio.file.Path;
-// import java.util.concurrent.Callable;
-// import lombok.RequiredArgsConstructor;
-// import picocli.CommandLine.Command;
-// import picocli.CommandLine.Option;
-//
-// @RequiredArgsConstructor
-// @Command(
-//     name = "get-jpa-entity-info",
-//     description = "Get necessary info of an specific Entity to create a JPA repository.")
-// public class GetJPAEntityInfoCommand
-//     implements Callable<DataTransferObject<GetJPAEntityInfoResponse>> {
-//   private final JavaCommandService javaCommandService;
-//
-//   @Option(names = "--cwd", description = "Current Working Directory", required = true)
-//   private Path cwd;
-//
-//   @Option(
-//       names = {"--file-path"},
-//       description = "The absolute path to the .java file.",
-//       required = true)
-//   private Path filePath;
-//
-//   @Option(
-//       names = "--ide",
-//       description = "The IDE the command is being called from.",
-//       required = true)
-//   private SupportedIDE ide = SupportedIDE.NONE;
-//
-//   @Override
-//   public DataTransferObject<GetJPAEntityInfoResponse> call() {
-//     return this.javaCommandService.getJPAEntityInfo(this.cwd, this.filePath, this.ide);
-//   }
-// }
+package io.github.syntaxpresso.core.command;
+
+import io.github.syntaxpresso.core.command.dto.GetJPAEntityInfoResponse;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.command.GetJPAEntityInfoCommandService;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import lombok.RequiredArgsConstructor;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@RequiredArgsConstructor
+@Command(
+    name = "get-jpa-entity-info",
+    description = "Get necessary info of an specific Entity to create a JPA repository.")
+public class GetJPAEntityInfoCommand
+    implements Callable<DataTransferObject<GetJPAEntityInfoResponse>> {
+  private final GetJPAEntityInfoCommandService getJPAEntityInfoCommandService;
+
+  @Option(names = "--cwd", description = "Current Working Directory", required = true)
+  private Path cwd;
+
+  @Option(
+      names = {"--file-path"},
+      description = "The absolute path to the .java file.",
+      required = true)
+  private Path filePath;
+
+  @Option(
+      names = "--language",
+      description = "The language related to the command execution.",
+      required = true)
+  private SupportedLanguage language;
+
+  @Option(
+      names = "--ide",
+      description = "The IDE the command is being called from.",
+      required = true)
+  private SupportedIDE ide = SupportedIDE.NONE;
+
+  @Option(
+      names = "--superclass-source",
+      description = "Base64 encoded source code of the superclass if needed.",
+      required = false)
+  private String superclassSource;
+
+  @Override
+  public DataTransferObject<GetJPAEntityInfoResponse> call() {
+    if (SupportedLanguage.JAVA.equals(this.language)) {
+      return this.getJPAEntityInfoCommandService.run(
+          this.cwd, this.filePath, this.language, this.ide, this.superclassSource);
+    }
+    return DataTransferObject.error("Language not supported.");
+  }
+}

--- a/src/main/java/io/github/syntaxpresso/core/command/dto/GetJPAEntityInfoResponse.java
+++ b/src/main/java/io/github/syntaxpresso/core/command/dto/GetJPAEntityInfoResponse.java
@@ -1,8 +1,6 @@
 package io.github.syntaxpresso.core.command.dto;
 
 import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
 import lombok.*;
 
 @Data
@@ -11,11 +9,9 @@ import lombok.*;
 @Builder
 public class GetJPAEntityInfoResponse implements Serializable {
   private Boolean isJPAEntity;
-  private String entityPath;
+  private String entityType;
   private String entityPackageName;
+  private String entityPath;
   private String idFieldType;
   private String idFieldPackageName;
-  private String recommendedRepositoryName;
-  private String recommendedRepositoryPackageName;
-  private List<Map<String, String>> recommendedTypes;
 }

--- a/src/main/java/io/github/syntaxpresso/core/common/CommandFactory.java
+++ b/src/main/java/io/github/syntaxpresso/core/common/CommandFactory.java
@@ -13,6 +13,7 @@ public class CommandFactory implements IFactory {
   private final GetCursorPositionInfoCommandService getCursorPositionInfoCommandService;
   private final CreateNewJPAEntityCommandService createNewJPAEntityCommandService;
   private final CreateJPARepositoryCommandService createJPARepositoryCommandService;
+  private final GetJPAEntityInfoCommandService getJPAEntityInfoCommandService;
   private final GetAllFilesCommandService getAllFilesCommandService;
 
   @Override
@@ -35,6 +36,9 @@ public class CommandFactory implements IFactory {
     }
     if (cls == CreateJPARepositoryCommand.class) {
       return (K) new CreateJPARepositoryCommand(createJPARepositoryCommandService);
+    }
+    if (cls == GetJPAEntityInfoCommand.class) {
+      return (K) new GetJPAEntityInfoCommand(getJPAEntityInfoCommandService);
     }
     if (cls == GetAllFilesCommand.class) {
       return (K) new GetAllFilesCommand(getAllFilesCommandService);

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/CreateJPARepositoryCommandService.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
-import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.treesitter.TSNode;
@@ -30,6 +29,7 @@ import org.treesitter.TSNode;
 public class CreateJPARepositoryCommandService {
   private final JavaLanguageService javaLanguageService;
   private final CreateNewFileCommandService createNewFileCommandService;
+  private final GetJPAEntityInfoCommandService getJPAEntityInfoCommandService;
 
   private JPARepositoryData buildJPARepositoryData(
       Path cwd, String entityType, String entityIdType, String entityPackageName) {
@@ -39,147 +39,6 @@ public class CreateJPARepositoryCommandService {
         .entityType(entityType)
         .entityIdType(entityIdType)
         .build();
-  }
-
-  private Optional<TSNode> getIdFieldFromEntity(TSFile tsFile, TSNode publicClassNode) {
-    List<TSNode> publicClassFieldNodes =
-        this.javaLanguageService
-            .getClassDeclarationService()
-            .getFieldDeclarationService()
-            .getAllFieldDeclarationNodes(tsFile, publicClassNode);
-    for (TSNode classFieldNode : publicClassFieldNodes) {
-      Optional<TSNode> idFieldAnnotation =
-          this.javaLanguageService
-              .getAnnotationService()
-              .findAnnotationByName(tsFile, classFieldNode, "Id");
-      if (idFieldAnnotation.isPresent()) {
-        return Optional.of(classFieldNode);
-      }
-    }
-    return Optional.empty();
-  }
-
-  private Optional<TSFile> findSuperclassFile(Path cwd, TSFile entityFile, TSNode publicClassNode) {
-    Optional<TSNode> superClassNameNode =
-        this.javaLanguageService
-            .getClassDeclarationService()
-            .getClassDeclarationSuperclassNameNode(entityFile, publicClassNode);
-    if (superClassNameNode.isEmpty()) {
-      return Optional.empty();
-    }
-    String superClassName = entityFile.getTextFromNode(superClassNameNode.get());
-    if (Strings.isNullOrEmpty(superClassName)) {
-      return Optional.empty();
-    }
-    List<TSFile> allJavaFiles = this.javaLanguageService.getAllJavaFilesFromCwd(cwd);
-    for (TSFile tsFile : allJavaFiles) {
-      Optional<String> fileName = tsFile.getFileNameWithoutExtension();
-      if (fileName.isEmpty()) {
-        continue;
-      }
-      if (fileName.get().equals(superClassName)) {
-        return Optional.of(tsFile);
-      }
-    }
-    return Optional.empty();
-  }
-
-  private IdFieldSearchResult findIdFieldRecursively(
-      Path cwd, TSFile tsFile, TSNode publicClassNode) {
-    return this.findIdFieldRecursively(cwd, tsFile, publicClassNode, null);
-  }
-
-  private IdFieldSearchResult findIdFieldRecursively(
-      Path cwd, TSFile tsFile, TSNode publicClassNode, TSFile externalSuperclassFile) {
-    Optional<TSNode> idFieldNode = this.getIdFieldFromEntity(tsFile, publicClassNode);
-    if (idFieldNode.isPresent()) {
-      return IdFieldSearchResult.found(tsFile, idFieldNode.get());
-    }
-    Optional<TSNode> superClassNameNode =
-        this.javaLanguageService
-            .getClassDeclarationService()
-            .getClassDeclarationSuperclassNameNode(tsFile, publicClassNode);
-    if (superClassNameNode.isEmpty()) {
-      return IdFieldSearchResult.notFound();
-    }
-    String superClassName = tsFile.getTextFromNode(superClassNameNode.get());
-    if (Strings.isNullOrEmpty(superClassName)) {
-      return IdFieldSearchResult.notFound();
-    }
-    // First check if we have an external superclass file for this superclass
-    if (externalSuperclassFile != null) {
-      // For external source, we can't use getPublicClass() as it requires a filename
-      // Instead, find any class declaration in the external source
-      Optional<TSNode> externalClassNode =
-          this.javaLanguageService
-              .getClassDeclarationService()
-              .getPublicClass(externalSuperclassFile);
-      if (externalClassNode.isPresent()) {
-        Optional<String> externalClassName =
-            this.extractEntityType(externalSuperclassFile, externalClassNode.get());
-        if (externalClassName.isPresent() && externalClassName.get().equals(superClassName)) {
-          // We found the matching external superclass, search within it
-          return this.findIdFieldRecursively(
-              cwd, externalSuperclassFile, externalClassNode.get(), null);
-        }
-      }
-      // If we have external source but it doesn't match the expected class name,
-      // don't ask for the same superclass again - treat as not found
-      return IdFieldSearchResult.notFound();
-    }
-    Optional<TSFile> superClassFile = this.findSuperclassFile(cwd, tsFile, publicClassNode);
-    if (superClassFile.isEmpty()) {
-      return IdFieldSearchResult.missingSuperclass(superClassName);
-    }
-    Optional<TSNode> superClassPublicNode =
-        this.javaLanguageService.getClassDeclarationService().getPublicClass(superClassFile.get());
-    if (superClassPublicNode.isEmpty()) {
-      return IdFieldSearchResult.notFound();
-    }
-    return this.findIdFieldRecursively(
-        cwd, superClassFile.get(), superClassPublicNode.get(), externalSuperclassFile);
-  }
-
-  private Optional<String> extractEntityType(TSFile tsFile, TSNode publicClassNode) {
-    Optional<TSNode> classNameNode =
-        this.javaLanguageService
-            .getClassDeclarationService()
-            .getClassDeclarationNameNode(tsFile, publicClassNode);
-    if (classNameNode.isEmpty()) {
-      return Optional.empty();
-    }
-    String className = tsFile.getTextFromNode(classNameNode.get());
-    return Strings.isNullOrEmpty(className) ? Optional.empty() : Optional.of(className);
-  }
-
-  private Optional<String> extractIdType(TSFile tsFile, TSNode idFieldNode) {
-    Optional<TSNode> fieldTypeNode =
-        this.javaLanguageService
-            .getClassDeclarationService()
-            .getFieldDeclarationService()
-            .getFieldDeclarationFullTypeNode(tsFile, idFieldNode);
-    if (fieldTypeNode.isEmpty()) {
-      return Optional.empty();
-    }
-    String idType = tsFile.getTextFromNode(fieldTypeNode.get());
-    return Strings.isNullOrEmpty(idType) ? Optional.empty() : Optional.of(idType);
-  }
-
-  private Optional<String> extractPackageName(TSFile tsFile) {
-    Optional<TSNode> packageDeclarationNode =
-        this.javaLanguageService.getPackageDeclarationService().getPackageDeclarationNode(tsFile);
-    if (packageDeclarationNode.isEmpty()) {
-      return Optional.empty();
-    }
-    Optional<TSNode> packageScopeNode =
-        this.javaLanguageService
-            .getPackageDeclarationService()
-            .getPackageScopeNode(tsFile, packageDeclarationNode.get());
-    if (packageScopeNode.isEmpty()) {
-      return Optional.empty();
-    }
-    String packageName = tsFile.getTextFromNode(packageScopeNode.get());
-    return Strings.isNullOrEmpty(packageName) ? Optional.empty() : Optional.of(packageName);
   }
 
   private DataTransferObject<CreateNewFileResponse> createRepositoryFile(
@@ -282,11 +141,12 @@ public class CreateJPARepositoryCommandService {
     if (entityPublicClassNode.isEmpty()) {
       return PrepareDataResult.error("No public class found in the entity file.");
     }
-    Optional<String> packageName = this.extractPackageName(tsFile);
+    Optional<String> packageName = this.getJPAEntityInfoCommandService.extractPackageName(tsFile);
     if (packageName.isEmpty()) {
       return PrepareDataResult.error("Package name could not be extracted from the entity file.");
     }
-    Optional<String> entityType = this.extractEntityType(tsFile, entityPublicClassNode.get());
+    Optional<String> entityType =
+        this.getJPAEntityInfoCommandService.extractEntityType(tsFile, entityPublicClassNode.get());
     if (entityType.isEmpty()) {
       return PrepareDataResult.error("Entity type could not be extracted from the entity file.");
     }
@@ -302,15 +162,18 @@ public class CreateJPARepositoryCommandService {
         return PrepareDataResult.error("No public class found in the entity file.");
       }
       searchResult =
-          this.findIdFieldRecursively(
+          this.getJPAEntityInfoCommandService.findIdFieldRecursively(
               cwd, externalSuperclassFile, externalSuperclassFilePublicClassNode.get());
     } else {
-      searchResult = this.findIdFieldRecursively(cwd, tsFile, entityPublicClassNode.get());
+      searchResult =
+          this.getJPAEntityInfoCommandService.findIdFieldRecursively(
+              cwd, tsFile, entityPublicClassNode.get());
     }
     if (searchResult.isFound()) {
       // Id field found - extract ID type and create JPARepositoryData
       Optional<String> idType =
-          this.extractIdType(searchResult.getTsFile(), searchResult.getIdFieldNode());
+          this.getJPAEntityInfoCommandService.extractIdType(
+              searchResult.getTsFile(), searchResult.getIdFieldNode());
       if (idType.isEmpty()) {
         return PrepareDataResult.error("ID field type could not be extracted.");
       }

--- a/src/main/java/io/github/syntaxpresso/core/service/java/command/GetJPAEntityInfoCommandService.java
+++ b/src/main/java/io/github/syntaxpresso/core/service/java/command/GetJPAEntityInfoCommandService.java
@@ -1,0 +1,242 @@
+package io.github.syntaxpresso.core.service.java.command;
+
+import com.google.common.base.Strings;
+import io.github.syntaxpresso.core.command.dto.GetJPAEntityInfoResponse;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.TSFile;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.JavaLanguageService;
+import io.github.syntaxpresso.core.service.java.command.extra.IdFieldSearchResult;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.treesitter.TSNode;
+
+@RequiredArgsConstructor
+public class GetJPAEntityInfoCommandService {
+  private final JavaLanguageService javaLanguageService;
+
+  public Optional<TSNode> getIdFieldFromEntity(TSFile tsFile, TSNode publicClassNode) {
+    List<TSNode> publicClassFieldNodes =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getFieldDeclarationService()
+            .getAllFieldDeclarationNodes(tsFile, publicClassNode);
+    for (TSNode classFieldNode : publicClassFieldNodes) {
+      Optional<TSNode> idFieldAnnotation =
+          this.javaLanguageService
+              .getAnnotationService()
+              .findAnnotationByName(tsFile, classFieldNode, "Id");
+      if (idFieldAnnotation.isPresent()) {
+        return Optional.of(classFieldNode);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public Optional<TSFile> findSuperclassFile(Path cwd, TSFile entityFile, TSNode publicClassNode) {
+    Optional<TSNode> superClassNameNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getClassDeclarationSuperclassNameNode(entityFile, publicClassNode);
+    if (superClassNameNode.isEmpty()) {
+      return Optional.empty();
+    }
+    String superClassName = entityFile.getTextFromNode(superClassNameNode.get());
+    if (Strings.isNullOrEmpty(superClassName)) {
+      return Optional.empty();
+    }
+    List<TSFile> allJavaFiles = this.javaLanguageService.getAllJavaFilesFromCwd(cwd);
+    for (TSFile tsFile : allJavaFiles) {
+      Optional<String> fileName = tsFile.getFileNameWithoutExtension();
+      if (fileName.isEmpty()) {
+        continue;
+      }
+      if (fileName.get().equals(superClassName)) {
+        return Optional.of(tsFile);
+      }
+    }
+    return Optional.empty();
+  }
+
+  public IdFieldSearchResult findIdFieldRecursively(
+      Path cwd, TSFile tsFile, TSNode publicClassNode) {
+    return this.findIdFieldRecursively(cwd, tsFile, publicClassNode, null);
+  }
+
+  public IdFieldSearchResult findIdFieldRecursively(
+      Path cwd, TSFile tsFile, TSNode publicClassNode, TSFile externalSuperclassFile) {
+    Optional<TSNode> idFieldNode = this.getIdFieldFromEntity(tsFile, publicClassNode);
+    if (idFieldNode.isPresent()) {
+      return IdFieldSearchResult.found(tsFile, idFieldNode.get());
+    }
+    Optional<TSNode> superClassNameNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getClassDeclarationSuperclassNameNode(tsFile, publicClassNode);
+    if (superClassNameNode.isEmpty()) {
+      return IdFieldSearchResult.notFound();
+    }
+    String superClassName = tsFile.getTextFromNode(superClassNameNode.get());
+    if (Strings.isNullOrEmpty(superClassName)) {
+      return IdFieldSearchResult.notFound();
+    }
+    // First check if we have an external superclass file for this superclass
+    if (externalSuperclassFile != null) {
+      // For external source, we can't use getPublicClass() as it requires a filename
+      // Instead, find any class declaration in the external source
+      Optional<TSNode> externalClassNode =
+          this.javaLanguageService
+              .getClassDeclarationService()
+              .getPublicClass(externalSuperclassFile);
+      if (externalClassNode.isPresent()) {
+        Optional<String> externalClassName =
+            this.extractEntityType(externalSuperclassFile, externalClassNode.get());
+        if (externalClassName.isPresent() && externalClassName.get().equals(superClassName)) {
+          // We found the matching external superclass, search within it
+          return this.findIdFieldRecursively(
+              cwd, externalSuperclassFile, externalClassNode.get(), null);
+        }
+      }
+      // If we have external source but it doesn't match the expected class name,
+      // don't ask for the same superclass again - treat as not found
+      return IdFieldSearchResult.notFound();
+    }
+    Optional<TSFile> superClassFile = this.findSuperclassFile(cwd, tsFile, publicClassNode);
+    if (superClassFile.isEmpty()) {
+      return IdFieldSearchResult.missingSuperclass(superClassName);
+    }
+    Optional<TSNode> superClassPublicNode =
+        this.javaLanguageService.getClassDeclarationService().getPublicClass(superClassFile.get());
+    if (superClassPublicNode.isEmpty()) {
+      return IdFieldSearchResult.notFound();
+    }
+    return this.findIdFieldRecursively(
+        cwd, superClassFile.get(), superClassPublicNode.get(), externalSuperclassFile);
+  }
+
+  public Optional<String> extractEntityType(TSFile tsFile, TSNode publicClassNode) {
+    Optional<TSNode> classNameNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getClassDeclarationNameNode(tsFile, publicClassNode);
+    if (classNameNode.isEmpty()) {
+      return Optional.empty();
+    }
+    String className = tsFile.getTextFromNode(classNameNode.get());
+    return Strings.isNullOrEmpty(className) ? Optional.empty() : Optional.of(className);
+  }
+
+  public Optional<String> extractIdType(TSFile tsFile, TSNode idFieldNode) {
+    Optional<TSNode> fieldTypeNode =
+        this.javaLanguageService
+            .getClassDeclarationService()
+            .getFieldDeclarationService()
+            .getFieldDeclarationFullTypeNode(tsFile, idFieldNode);
+    if (fieldTypeNode.isEmpty()) {
+      return Optional.empty();
+    }
+    String idType = tsFile.getTextFromNode(fieldTypeNode.get());
+    return Strings.isNullOrEmpty(idType) ? Optional.empty() : Optional.of(idType);
+  }
+
+  public Optional<String> extractPackageName(TSFile tsFile) {
+    Optional<TSNode> packageDeclarationNode =
+        this.javaLanguageService.getPackageDeclarationService().getPackageDeclarationNode(tsFile);
+    if (packageDeclarationNode.isEmpty()) {
+      return Optional.empty();
+    }
+    Optional<TSNode> packageScopeNode =
+        this.javaLanguageService
+            .getPackageDeclarationService()
+            .getPackageScopeNode(tsFile, packageDeclarationNode.get());
+    if (packageScopeNode.isEmpty()) {
+      return Optional.empty();
+    }
+    String packageName = tsFile.getTextFromNode(packageScopeNode.get());
+    return Strings.isNullOrEmpty(packageName) ? Optional.empty() : Optional.of(packageName);
+  }
+
+  public boolean isJPAEntity(TSFile tsFile, TSNode publicClassNode) {
+    Optional<TSNode> entityAnnotation =
+        this.javaLanguageService
+            .getAnnotationService()
+            .findAnnotationByName(tsFile, publicClassNode, "Entity");
+    return entityAnnotation.isPresent();
+  }
+
+  public DataTransferObject<GetJPAEntityInfoResponse> run(
+      Path cwd,
+      Path filePath,
+      SupportedLanguage language,
+      SupportedIDE ide,
+      String superclassSource) {
+    String decodedSuperclassSource = null;
+    if (!Strings.isNullOrEmpty(superclassSource)) {
+      try {
+        decodedSuperclassSource = new String(Base64.getDecoder().decode(superclassSource));
+      } catch (IllegalArgumentException e) {
+        return DataTransferObject.error(
+            "Invalid base64 encoding in superclass source: " + e.getMessage());
+      }
+    }
+    TSFile tsFile = new TSFile(language, filePath);
+    Optional<TSNode> entityPublicClassNode =
+        this.javaLanguageService.getClassDeclarationService().getPublicClass(tsFile);
+    if (entityPublicClassNode.isEmpty()) {
+      return DataTransferObject.error("No public class found in the entity file.");
+    }
+    Optional<String> packageName = this.extractPackageName(tsFile);
+    if (packageName.isEmpty()) {
+      return DataTransferObject.error("Package name could not be extracted from the entity file.");
+    }
+    Optional<String> entityType = this.extractEntityType(tsFile, entityPublicClassNode.get());
+    if (entityType.isEmpty()) {
+      return DataTransferObject.error("Entity type could not be extracted from the entity file.");
+    }
+    boolean isJPAEntity = this.isJPAEntity(tsFile, entityPublicClassNode.get());
+    // Search for @Id field
+    IdFieldSearchResult searchResult;
+    TSFile externalSuperclassFile = null;
+    if (!Strings.isNullOrEmpty(decodedSuperclassSource)) {
+      externalSuperclassFile = new TSFile(SupportedLanguage.JAVA, decodedSuperclassSource);
+      Optional<TSNode> externalSuperclassFilePublicClassNode =
+          this.javaLanguageService
+              .getClassDeclarationService()
+              .getPublicClass(externalSuperclassFile);
+      if (externalSuperclassFilePublicClassNode.isEmpty()) {
+        return DataTransferObject.error("No public class found in the superclass source.");
+      }
+      searchResult =
+          this.findIdFieldRecursively(
+              cwd, externalSuperclassFile, externalSuperclassFilePublicClassNode.get());
+    } else {
+      searchResult = this.findIdFieldRecursively(cwd, tsFile, entityPublicClassNode.get());
+    }
+    String idFieldType = null;
+    String idFieldPackageName = null;
+    if (searchResult.isFound()) {
+      Optional<String> idType =
+          this.extractIdType(searchResult.getTsFile(), searchResult.getIdFieldNode());
+      if (idType.isPresent()) {
+        idFieldType = idType.get();
+        // Try to extract package name for the ID field type
+        Optional<String> idPackage = this.extractPackageName(searchResult.getTsFile());
+        idFieldPackageName = idPackage.orElse(null);
+      }
+    }
+    GetJPAEntityInfoResponse response =
+        GetJPAEntityInfoResponse.builder()
+            .isJPAEntity(isJPAEntity)
+            .entityType(entityType.get())
+            .entityPackageName(packageName.get())
+            .entityPath(tsFile.getFile().getAbsolutePath())
+            .idFieldType(idFieldType)
+            .idFieldPackageName(idFieldPackageName)
+            .build();
+    return DataTransferObject.success(response);
+  }
+}

--- a/src/test/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommandTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/command/CreateJPARepositoryCommandTest.java
@@ -574,7 +574,7 @@ class CreateJPARepositoryCommandTest {
     private String lastCalledSuperclassSource;
 
     public TestCreateJPARepositoryCommandService() {
-      super(null, null); // Mock dependencies are not used in tests
+      super(null, null, null); // Mock dependencies are not used in tests
     }
 
     @Override

--- a/src/test/java/io/github/syntaxpresso/core/command/GetJPAEntityInfoCommandTest.java
+++ b/src/test/java/io/github/syntaxpresso/core/command/GetJPAEntityInfoCommandTest.java
@@ -1,0 +1,319 @@
+package io.github.syntaxpresso.core.command;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.syntaxpresso.core.command.dto.GetJPAEntityInfoResponse;
+import io.github.syntaxpresso.core.common.DataTransferObject;
+import io.github.syntaxpresso.core.common.extra.SupportedIDE;
+import io.github.syntaxpresso.core.common.extra.SupportedLanguage;
+import io.github.syntaxpresso.core.service.java.command.GetJPAEntityInfoCommandService;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Comprehensive tests for GetJPAEntityInfoCommand.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ * GetJPAEntityInfoCommand command = new GetJPAEntityInfoCommand(service);
+ * // Set command options: --cwd /path/to/project --file-path /path/to/Entity.java --language JAVA --ide NONE
+ * DataTransferObject&lt;GetJPAEntityInfoResponse&gt; result = command.call();
+ * if (result.getSucceed()) {
+ *     GetJPAEntityInfoResponse response = result.getData();
+ *     System.out.println("Entity type: " + response.getEntityType());
+ *     System.out.println("ID field type: " + response.getIdFieldType());
+ *     System.out.println("Is JPA Entity: " + response.getIsJPAEntity());
+ * }
+ * </pre>
+ */
+@DisplayName("GetJPAEntityInfoCommand Tests")
+class GetJPAEntityInfoCommandTest {
+  private GetJPAEntityInfoCommand getJPAEntityInfoCommand;
+  private TestGetJPAEntityInfoCommandService testService;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  void setUp() {
+    this.testService = new TestGetJPAEntityInfoCommandService();
+    this.getJPAEntityInfoCommand = new GetJPAEntityInfoCommand(this.testService);
+  }
+
+  @Nested
+  @DisplayName("Java language support tests")
+  class JavaLanguageSupportTests {
+    @Test
+    @DisplayName("Should successfully analyze JPA entity for Java language")
+    void shouldSuccessfullyAnalyzeJPAEntityForJavaLanguage() throws Exception {
+      // Given
+      Path entityFilePath = createTestEntityFile();
+      GetJPAEntityInfoResponse expectedResponse =
+          GetJPAEntityInfoResponse.builder()
+              .isJPAEntity(true)
+              .entityType("User")
+              .entityPackageName("com.example.model")
+              .entityPath(entityFilePath.toString())
+              .idFieldType("Long")
+              .idFieldPackageName("java.lang")
+              .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupGetJPAEntityInfoCommand(
+          tempDir, entityFilePath, SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<GetJPAEntityInfoResponse> result = getJPAEntityInfoCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertNotNull(result.getData());
+      assertEquals(true, result.getData().getIsJPAEntity());
+      assertEquals("User", result.getData().getEntityType());
+      assertEquals("com.example.model", result.getData().getEntityPackageName());
+      assertEquals("Long", result.getData().getIdFieldType());
+
+      // Verify service was called with correct parameters
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(tempDir, testService.getLastCalledCwd());
+      assertEquals(entityFilePath, testService.getLastCalledFilePath());
+      assertEquals(SupportedLanguage.JAVA, testService.getLastCalledLanguage());
+      assertEquals(SupportedIDE.NONE, testService.getLastCalledIDE());
+    }
+
+    @Test
+    @DisplayName("Should handle service error responses for Java")
+    void shouldHandleServiceErrorResponsesForJava() throws Exception {
+      // Given
+      Path entityFilePath = createTestEntityFile();
+      testService.setErrorResponse("No public class found in the entity file.");
+      setupGetJPAEntityInfoCommand(
+          tempDir, entityFilePath, SupportedLanguage.JAVA, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<GetJPAEntityInfoResponse> result = getJPAEntityInfoCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertNull(result.getData());
+      assertEquals("No public class found in the entity file.", result.getErrorReason());
+      assertTrue(testService.wasServiceCalled());
+    }
+
+    @Test
+    @DisplayName("Should pass superclass source when provided")
+    void shouldPassSuperclassSourceWhenProvided() throws Exception {
+      // Given
+      Path entityFilePath = createTestEntityFile();
+      String superclassSource = "public class BaseEntity { @Id private Long id; }";
+      String encodedSuperclassSource =
+          Base64.getEncoder().encodeToString(superclassSource.getBytes());
+
+      GetJPAEntityInfoResponse expectedResponse =
+          GetJPAEntityInfoResponse.builder()
+              .isJPAEntity(true)
+              .entityType("User")
+              .entityPackageName("com.example.model")
+              .entityPath(entityFilePath.toString())
+              .idFieldType("Long")
+              .idFieldPackageName("java.lang")
+              .build();
+      testService.setSuccessResponse(expectedResponse);
+      setupGetJPAEntityInfoCommand(
+          tempDir,
+          entityFilePath,
+          SupportedLanguage.JAVA,
+          SupportedIDE.NONE,
+          encodedSuperclassSource);
+
+      // When
+      DataTransferObject<GetJPAEntityInfoResponse> result = getJPAEntityInfoCommand.call();
+
+      // Then
+      assertTrue(result.getSucceed());
+      assertTrue(testService.wasServiceCalled());
+      assertEquals(encodedSuperclassSource, testService.getLastCalledSuperclassSource());
+    }
+  }
+
+  @Nested
+  @DisplayName("Unsupported language tests")
+  class UnsupportedLanguageTests {
+    @Test
+    @DisplayName("Should return error for unsupported language")
+    void shouldReturnErrorForUnsupportedLanguage() throws Exception {
+      // Given
+      Path entityFilePath = createTestEntityFile();
+      // Use reflection to mock an unsupported language by setting language to null
+      setupGetJPAEntityInfoCommandWithNullLanguage(
+          tempDir, entityFilePath, SupportedIDE.NONE, null);
+
+      // When
+      DataTransferObject<GetJPAEntityInfoResponse> result = getJPAEntityInfoCommand.call();
+
+      // Then
+      assertFalse(result.getSucceed());
+      assertNull(result.getData());
+      assertEquals("Language not supported.", result.getErrorReason());
+      assertFalse(testService.wasServiceCalled());
+    }
+  }
+
+  private Path createTestEntityFile() throws IOException {
+    Path entityFile = tempDir.resolve("User.java");
+    String entityContent =
+        "package com.example.model;\n"
+            + "\n"
+            + "import jakarta.persistence.*;\n"
+            + "\n"
+            + "@Entity\n"
+            + "@Table(name = \"users\")\n"
+            + "public class User {\n"
+            + "    @Id\n"
+            + "    @GeneratedValue(strategy = GenerationType.IDENTITY)\n"
+            + "    private Long id;\n"
+            + "    \n"
+            + "    private String name;\n"
+            + "    private String email;\n"
+            + "}\n";
+    Files.writeString(entityFile, entityContent);
+    return entityFile;
+  }
+
+  private void setupGetJPAEntityInfoCommand(
+      Path cwd,
+      Path filePath,
+      SupportedLanguage language,
+      SupportedIDE ide,
+      String superclassSource) {
+    try {
+      // Use reflection to set private fields since they're annotated with @Option
+      var cwdField = GetJPAEntityInfoCommand.class.getDeclaredField("cwd");
+      cwdField.setAccessible(true);
+      cwdField.set(getJPAEntityInfoCommand, cwd);
+
+      var filePathField = GetJPAEntityInfoCommand.class.getDeclaredField("filePath");
+      filePathField.setAccessible(true);
+      filePathField.set(getJPAEntityInfoCommand, filePath);
+
+      var languageField = GetJPAEntityInfoCommand.class.getDeclaredField("language");
+      languageField.setAccessible(true);
+      languageField.set(getJPAEntityInfoCommand, language);
+
+      var ideField = GetJPAEntityInfoCommand.class.getDeclaredField("ide");
+      ideField.setAccessible(true);
+      ideField.set(getJPAEntityInfoCommand, ide);
+
+      if (superclassSource != null) {
+        var superclassSourceField =
+            GetJPAEntityInfoCommand.class.getDeclaredField("superclassSource");
+        superclassSourceField.setAccessible(true);
+        superclassSourceField.set(getJPAEntityInfoCommand, superclassSource);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to setup command", e);
+    }
+  }
+
+  private void setupGetJPAEntityInfoCommandWithNullLanguage(
+      Path cwd, Path filePath, SupportedIDE ide, String superclassSource) {
+    try {
+      // Use reflection to set private fields since they're annotated with @Option
+      var cwdField = GetJPAEntityInfoCommand.class.getDeclaredField("cwd");
+      cwdField.setAccessible(true);
+      cwdField.set(getJPAEntityInfoCommand, cwd);
+
+      var filePathField = GetJPAEntityInfoCommand.class.getDeclaredField("filePath");
+      filePathField.setAccessible(true);
+      filePathField.set(getJPAEntityInfoCommand, filePath);
+
+      var languageField = GetJPAEntityInfoCommand.class.getDeclaredField("language");
+      languageField.setAccessible(true);
+      languageField.set(
+          getJPAEntityInfoCommand, null); // Set to null to simulate unsupported language
+
+      var ideField = GetJPAEntityInfoCommand.class.getDeclaredField("ide");
+      ideField.setAccessible(true);
+      ideField.set(getJPAEntityInfoCommand, ide);
+
+      if (superclassSource != null) {
+        var superclassSourceField =
+            GetJPAEntityInfoCommand.class.getDeclaredField("superclassSource");
+        superclassSourceField.setAccessible(true);
+        superclassSourceField.set(getJPAEntityInfoCommand, superclassSource);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to setup command", e);
+    }
+  }
+
+  /** Test implementation of GetJPAEntityInfoCommandService for testing purposes. */
+  private static class TestGetJPAEntityInfoCommandService extends GetJPAEntityInfoCommandService {
+    private DataTransferObject<GetJPAEntityInfoResponse> responseToReturn;
+    private boolean serviceCalled = false;
+    private Path lastCalledCwd;
+    private Path lastCalledFilePath;
+    private SupportedLanguage lastCalledLanguage;
+    private SupportedIDE lastCalledIDE;
+    private String lastCalledSuperclassSource;
+
+    public TestGetJPAEntityInfoCommandService() {
+      super(null); // Mock dependencies are not used in tests
+    }
+
+    @Override
+    public DataTransferObject<GetJPAEntityInfoResponse> run(
+        Path cwd,
+        Path filePath,
+        SupportedLanguage language,
+        SupportedIDE ide,
+        String superclassSource) {
+      this.serviceCalled = true;
+      this.lastCalledCwd = cwd;
+      this.lastCalledFilePath = filePath;
+      this.lastCalledLanguage = language;
+      this.lastCalledIDE = ide;
+      this.lastCalledSuperclassSource = superclassSource;
+      return this.responseToReturn;
+    }
+
+    public void setSuccessResponse(GetJPAEntityInfoResponse response) {
+      this.responseToReturn = DataTransferObject.success(response);
+    }
+
+    public void setErrorResponse(String errorMessage) {
+      this.responseToReturn = DataTransferObject.error(errorMessage);
+    }
+
+    public boolean wasServiceCalled() {
+      return this.serviceCalled;
+    }
+
+    public Path getLastCalledCwd() {
+      return this.lastCalledCwd;
+    }
+
+    public Path getLastCalledFilePath() {
+      return this.lastCalledFilePath;
+    }
+
+    public SupportedLanguage getLastCalledLanguage() {
+      return this.lastCalledLanguage;
+    }
+
+    public SupportedIDE getLastCalledIDE() {
+      return this.lastCalledIDE;
+    }
+
+    public String getLastCalledSuperclassSource() {
+      return this.lastCalledSuperclassSource;
+    }
+  }
+}
+


### PR DESCRIPTION
This pull request introduces a new command for retrieving JPA entity information and refactors related code to improve modularity and maintainability. The most significant changes are the addition of the `GetJPAEntityInfoCommand`, updates to the command factory and core registration, and the extraction of entity info logic from `CreateJPARepositoryCommandService` into its own service.

### New JPA Entity Info Command Integration

* Added the `GetJPAEntityInfoCommand` and its service, enabling retrieval of JPA entity metadata via a dedicated command. This includes new options for language and superclass source, and refactors the command to use `GetJPAEntityInfoCommandService`. (`[src/main/java/io/github/syntaxpresso/core/command/GetJPAEntityInfoCommand.javaL1-R57](diffhunk://#diff-e4b402f20ebe57c69cc8c3346e766c14cd9b3c2942d99674ab83f2ebb61b160aL1-R57)`)
* Registered `GetJPAEntityInfoCommand` in the `Core` class and updated the command factory to support instantiation and dependency injection for the new command and service. (`[[1]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R26)`, `[[2]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R108-R111)`, `[[3]](diffhunk://#diff-26b31ad07d84438009fc39d00422d75b4f792c1083ff8e4930b4eaa036ac5777R121)`, `[[4]](diffhunk://#diff-13b624bcdb527541bb3e838a21909a3d6f03ec08bad3788c5d634ccfed3275f9R16)`, `[[5]](diffhunk://#diff-13b624bcdb527541bb3e838a21909a3d6f03ec08bad3788c5d634ccfed3275f9R40-R42)`)

### Refactoring and Codebase Simplification

* Extracted JPA entity info logic (such as finding ID fields, extracting types, and package names) from `CreateJPARepositoryCommandService` into `GetJPAEntityInfoCommandService`, reducing duplication and improving separation of concerns. Calls to these methods are now delegated to the new service. (`[[1]](diffhunk://#diff-18fe4be4b7238cc5913a580805620585bf0cefde679bda247eb17e82b740451fR32)`, `[[2]](diffhunk://#diff-18fe4be4b7238cc5913a580805620585bf0cefde679bda247eb17e82b740451fL285-R149)`, `[[3]](diffhunk://#diff-18fe4be4b7238cc5913a580805620585bf0cefde679bda247eb17e82b740451fL305-R176)`)
* Removed unused imports and internal methods from `CreateJPARepositoryCommandService` that are now handled by the new service. (`[[1]](diffhunk://#diff-18fe4be4b7238cc5913a580805620585bf0cefde679bda247eb17e82b740451fL24)`, `[[2]](diffhunk://#diff-18fe4be4b7238cc5913a580805620585bf0cefde679bda247eb17e82b740451fL44-L184)`)

### DTO and API Changes

* Updated the `GetJPAEntityInfoResponse` DTO to clarify field names (`entityType` instead of `entityPath`), remove unused fields, and improve semantic clarity of the response. (`[[1]](diffhunk://#diff-ed335f6d0554fa9af29a5e1bca6fe719f70ff26adbfefe5d4500b58582d2f6f7L4-L5)`, `[[2]](diffhunk://#diff-ed335f6d0554fa9af29a5e1bca6fe719f70ff26adbfefe5d4500b58582d2f6f7L14-L20)`)